### PR TITLE
Add User Nickname

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ import { ReactComponent as StartingPageBackground } from './icons/starting-page-
 const customConstants = {
   applicationId: 'AE8F7EEA-4555-4F86-AD8B-5E0BD86BFE67', // Your Sendbird application ID
   botId: 'khan-academy-bot', // Your Sendbird bot ID
-  botNickName: 'Jake Sully',
+  botNickName: 'Khan Academy Support Bot',
+  userNickName: 'User',
   betaMark: true,
   suggestedMessageContent: {
     replyContents: [
@@ -164,6 +165,7 @@ const App = () => {
       applicationId={customConstants.applicationId}
       botId={customConstants.botId}
       botNickName={customConstants.botNickName}
+      userNickName={customConstants.userNickName}
       betaMark={customConstants.betaMark}
       suggestedMessageContent={customConstants.suggestedMessageContent}
       createGroupChannelParams={customConstants.createGroupChannelParams}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ const App = (props: Props) => {
       applicationId={props.applicationId}
       botId={props.botId}
       botNickName={props.botNickName}
+      userNickName={props.userNickName}
       betaMark={props.betaMark}
       suggestedMessageContent={props.suggestedMessageContent}
       createGroupChannelParams={props.createGroupChannelParams}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -12,7 +12,7 @@ import SBConnectionStateProvider, {
 import { assert } from '../utils';
 
 const SBComponent = () => {
-  const { applicationId, botId, botNickName } = useConstantState();
+  const { applicationId, botId, userNickName } = useConstantState();
 
   assert(
     applicationId !== null && botId !== null,
@@ -33,7 +33,7 @@ const SBComponent = () => {
     <SBProvider
       appId={applicationId}
       userId={USER_ID}
-      nickname={botNickName}
+      nickname={userNickName}
       customApiHost={`https://api-${applicationId}.sendbird.com`}
       customWebSocketHost={`wss://ws-${applicationId}.sendbird.com`}
     >

--- a/src/const.ts
+++ b/src/const.ts
@@ -8,7 +8,8 @@ export const USER_ID = uuid();
 // get your app_id -> https://dashboard.sendbird.com/auth/signin
 
 export const DEFAULT_CONSTANT: Constant = {
-  botNickName: 'Jake Sully',
+  botNickName: 'Khan Academy Support Bot',
+  userNickName: 'User',
   betaMark: true,
   suggestedMessageContent: {
     replyContents: [
@@ -80,6 +81,7 @@ export const DEFAULT_CONSTANT: Constant = {
 
 export interface Constant {
   botNickName: string;
+  userNickName: string;
   betaMark: boolean;
   suggestedMessageContent: SuggestedMessageContent;
   createGroupChannelParams: CreateGroupChannelParams;

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -22,6 +22,7 @@ export const ConstantStateProvider = (props: ProviderProps) => {
       applicationId: props.applicationId,
       botId: props.botId,
       botNickName: props.botNickName ?? initialState.botNickName,
+      userNickName: props.userNickName ?? initialState.userNickName,
       betaMark: props.betaMark ?? initialState.betaMark,
       suggestedMessageContent:
         props.suggestedMessageContent ?? initialState.suggestedMessageContent,


### PR DESCRIPTION
### What's the issue?

Currently, BotNickname and UserNickname are being used interchangeably and without distinction.

<img width="300" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/104121286/5e393bf1-0647-4434-99cd-c6d1982ff45b">

<img width="800" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/104121286/dda31e01-617f-41ea-bf2a-59eed50a48d3">

### Changes

I've added a UserNickname. The UserNickname is used for the user's nickname in the chat room.