### PR TITLE
fix: flaky connection after 1st channel creation

### DIFF
--- a/src/components/CustomChannel.tsx
+++ b/src/components/CustomChannel.tsx
@@ -27,7 +27,7 @@ function Channel(props) {
         // Initialize the timestamp to be sure the first message is successfully sent,
         // and then render the channel UI after 1 second.
         setInitialTimeStamp(null);
-      }, 1000);
+      }, 500);
     }
   }, [sbConnectionStatus]);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,5 +207,11 @@ export function assert(condition: any, message: string): asserts condition {
   }
 }
 
+export function delay(delayTime: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayTime);
+  });
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export function noop() {}


### PR DESCRIPTION
![Screenshot 2023-07-18 at 3 38 05 PM](https://github.com/sendbird/chat-ai-widget/assets/10060731/80985a9e-ec8f-477e-a962-2ff566051510)


### What's the issue?
Sometimes the first bot reply is not being sent correctly and displays "..." indefinitely. I believe this is due to the timing of the connection after channel creation and user message sending.

### How did I solve it?
I couldn't find a clear solution because I currently only have a hypothesis as mentioned above. 
So, I cleaned up the async function calls in `createAndSetNewChannel` and added a 1-second delay at the end of it. 
I can't say the issue is completely resolved, but it seems to reduce the likelihood.