### PR TITLE
feat: apply appStateToggleEnabled init param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "dependencies": {
         "@sendbird/chat": "^4.9.3",
-        "@sendbird/uikit-react": "^3.6.4",
+        "@sendbird/uikit-react": "3.6.5",
         "dompurify": "^3.0.4",
         "polished": "^2.3.1",
         "react-code-blocks": "^0.1.0",
@@ -1032,9 +1032,9 @@
       }
     },
     "node_modules/@sendbird/uikit-react": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@sendbird/uikit-react/-/uikit-react-3.6.4.tgz",
-      "integrity": "sha512-ijThkIvWBl8IgEyPqIMEwK71pJxxIV8rwxYiZTJIZV4YdfHKcrxZ64rOVlU4wiP7Rx6oc++gwpmiYcWlhjZx+A==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@sendbird/uikit-react/-/uikit-react-3.6.5.tgz",
+      "integrity": "sha512-5SCy8xklAGDEepG7wcJ/uU2meXPUV4w2cprG4bsX7T+vE09AuI9BDlXwa4lCesuK3l6cH88r8YIaCfJ9ZRqqeQ==",
       "dependencies": {
         "@sendbird/chat": "^4.9.2",
         "@sendbird/uikit-tools": "0.0.1-alpha.40",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@sendbird/chat": "^4.9.3",
-    "@sendbird/uikit-react": "^3.6.4",
+    "@sendbird/uikit-react": "3.6.5",
     "dompurify": "^3.0.4",
     "polished": "^2.3.1",
     "react-code-blocks": "^0.1.0",

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -10,6 +10,7 @@ import SBConnectionStateProvider, {
   useSbConnectionState,
 } from '../context/SBConnectionContext';
 import { assert } from '../utils';
+import { useMemo } from 'react';
 
 const SBComponent = () => {
   const { applicationId, botId, userNickName } = useConstantState();
@@ -19,6 +20,9 @@ const SBComponent = () => {
     'applicationId and botId must be provided'
   );
   const { sbConnectionStatus } = useSbConnectionState();
+  const sdkInitParams = useMemo(() => ({
+    appStateToggleEnabled: false,
+  }), []);
 
   // Until the user sends a first message,
   // we will display a fake channel UI not to establish a connection to Sendbird Chat SDK
@@ -36,6 +40,7 @@ const SBComponent = () => {
       nickname={userNickName}
       customApiHost={`https://api-${applicationId}.sendbird.com`}
       customWebSocketHost={`wss://ws-${applicationId}.sendbird.com`}
+      sdkInitParams={sdkInitParams}
     >
       <>
         <CustomChannel />


### PR DESCRIPTION
Even after https://github.com/sendbird/chat-ai-widget/pull/11 merged, the channel is still refreshed due to the sdk reconnection. It's because the sdk's default behavior https://github.com/sendbird/chat-js/blob/develop-v4/src/comm/appStateChangeDetector.ts#L26. So I had to add a new option; `sdkInitParams` to UIKit https://github.com/sendbird/sendbird-uikit-react/pull/692 so we can pass the sdk init option param.

By passing [`appStateToggleEnabled: false`](https://sendbird.com/docs/chat/v4/javascript/ref/interfaces/_sendbird_chat.SendbirdChatParams.html#appStateToggleEnabled) when `sdk.init()` is called, we'll be able to prevent this unnecessary channel refresh. 
