### PR TITLE
Fix build script to exclude when build and set text align

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   "scripts": {
     "dev": "vite",
     "build:types": "rm -rf dist; rm -rf icons; rm -rf icons; tsc; cp -R src/icons icons; cp -R src/icons dist/icons ; cp -R src/css css; cp -R src/css dist/css",
-    "prebuild": "rm -rf ./dist",
-    "build": "npm run prebuild && tsc-silent -p './tsconfig.json' --suppress @ && vite build",
+    "prebuild": "rm -rf ./dist && mv .env .env_temp || true",
+    "postbuild": "mv .env_temp .env || true",
+    "build": "npm run prebuild && tsc-silent -p './tsconfig.json' --suppress @ && vite build && npm run postbuild",
     "build:pages": "npm run prebuild && tsc-silent -p './tsconfig.json' --suppress @ && vite build --config vite.config.pages.ts",
     "lint": "npx eslint src",
     "lint:fix": "npm run lint -- --fix",

--- a/src/components/BotMessageWithBodyInput.tsx
+++ b/src/components/BotMessageWithBodyInput.tsx
@@ -81,7 +81,14 @@ export default function BotMessageWithBodyInput(props: Props) {
         />
       </ImageContainer>
       <BodyContainer style={bodyStyle ?? {}}>
-        <Sender isStartingPage={messageCount === 1}>{botUser.nickname}</Sender>
+        <Sender
+          style={{
+            textAlign: 'left',
+          }}
+          isStartingPage={messageCount === 1}
+        >
+          {botUser.nickname}
+        </Sender>
         {bodyComponent}
       </BodyContainer>
       <SentTime>{formatCreatedAtToAMPM(message.createdAt)}</SentTime>


### PR DESCRIPTION
<img width="300" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/104121286/ed034a4c-7236-40c5-a7a3-7e25e8433fc4">

### What's the issue?
[Slack](https://sendbird.slack.com/archives/C0593MY7KMG/p1689924369178099)
In version 1.0.1, if built while .env file exists, there is an issue where the default `applicationId` and `botId` values get set

### How did I solve it?
Added logic to change `.env` to `.env_temp` pre build, and then revert it back post build. Additionally, fixed the issue where the chat message sender's text_align was set to center.