### PR TITLE
feat: add instantConnect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ const App = () => {
       botNickName={customConstants.botNickName}
       userNickName={customConstants.userNickName}
       betaMark={customConstants.betaMark}
+      customBetaMarkText={customConstants.customBetaMarkText}
       suggestedMessageContent={customConstants.suggestedMessageContent}
       createGroupChannelParams={customConstants.createGroupChannelParams}
       startingPageContent={customConstants.startingPageContent}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,6 @@ const App = (props: Props) => {
       replacementTextList={props.replacementTextList}
       hashedKey={props.hashedKey}
       instantConnect={props.instantConnect}
-      showChatBottom={props.showChatBottom}
     />
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ const App = (props: Props) => {
       botNickName={props.botNickName}
       userNickName={props.userNickName}
       betaMark={props.betaMark}
+      customBetaMarkText={props.customBetaMarkText}
       suggestedMessageContent={props.suggestedMessageContent}
       createGroupChannelParams={props.createGroupChannelParams}
       startingPageContent={props.startingPageContent}
@@ -22,6 +23,8 @@ const App = (props: Props) => {
       messageBottomContent={props.messageBottomContent}
       replacementTextList={props.replacementTextList}
       hashedKey={props.hashedKey}
+      instantConnect={props.instantConnect}
+      showChatBottom={props.showChatBottom}
     />
   );
 };

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,10 +1,17 @@
+import '@sendbird/uikit-react/dist/index.css';
+import '../css/index.css';
 import SBProvider from '@sendbird/uikit-react/SendbirdProvider';
 import { useMemo } from 'react';
 
+import { type Props as ChatWidgetProps } from './ChatAiWidget';
 import CustomChannel from './CustomChannel';
 import { StartingPage } from './StartingPage';
 import { USER_ID } from '../const';
-import { useConstantState } from '../context/ConstantContext';
+import {
+  useConstantState,
+  ConstantStateProvider,
+} from '../context/ConstantContext';
+import { HashedKeyProvider } from '../context/HashedKeyContext';
 import SBConnectionStateProvider, {
   useSbConnectionState,
 } from '../context/SBConnectionContext';
@@ -51,11 +58,34 @@ const SBComponent = () => {
   );
 };
 
-const Chat = () => {
+const Chat = ({
+  applicationId,
+  botId,
+  hashedKey,
+  ...constantProps
+}: ChatWidgetProps) => {
+  const CHAT_WIDGET_APP_ID = import.meta.env.VITE_CHAT_WIDGET_APP_ID;
+  const CHAT_WIDGET_BOT_ID = import.meta.env.VITE_CHAT_WIDGET_BOT_ID;
+
+  assert(
+    applicationId !== null && botId !== null,
+    'applicationId and botId must be provided'
+  );
+
   return (
-    <SBConnectionStateProvider>
-      <SBComponent />
-    </SBConnectionStateProvider>
+    <ConstantStateProvider
+      // If env is not provided, prop will be used instead.
+      // But Either should be provided.
+      applicationId={CHAT_WIDGET_APP_ID ?? applicationId}
+      botId={CHAT_WIDGET_BOT_ID ?? botId}
+      {...constantProps}
+    >
+      <HashedKeyProvider hashedKey={hashedKey ?? null}>
+        <SBConnectionStateProvider>
+          <SBComponent />
+        </SBConnectionStateProvider>
+      </HashedKeyProvider>
+    </ConstantStateProvider>
   );
 };
 

--- a/src/components/ChatAiWidget.tsx
+++ b/src/components/ChatAiWidget.tsx
@@ -5,11 +5,8 @@ import styled, { css } from 'styled-components';
 
 import WidgetWindow from './WidgetWindow';
 import { Constant } from '../const';
-import { ConstantStateProvider } from '../context/ConstantContext';
-import { HashedKeyProvider } from '../context/HashedKeyContext';
 import { ReactComponent as ArrowDownIcon } from '../icons/ic-arrow-down.svg';
 import { ReactComponent as ChatBotIcon } from '../icons/icon-widget-chatbot.svg';
-import { assert } from '../utils';
 
 const StyledWidgetButtonWrapper = styled.button`
   position: fixed;
@@ -105,21 +102,13 @@ const getCookie = (cookieName: string) => {
   return cookies.filter((cookie) => cookie.includes(`${cookieName}=`));
 };
 
-const CHAT_WIDGET_APP_ID = import.meta.env.VITE_CHAT_WIDGET_APP_ID;
-const CHAT_WIDGET_BOT_ID = import.meta.env.VITE_CHAT_WIDGET_BOT_ID;
-
-interface Props extends Partial<Constant> {
+export interface Props extends Partial<Constant> {
   applicationId?: string;
   botId?: string;
   hashedKey?: string;
 }
 
-const ChatAiWidget = ({
-  applicationId,
-  botId,
-  hashedKey,
-  ...constantProps
-}: Props) => {
+const ChatAiWidget = (props: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const timer = useRef<NodeJS.Timeout | null>(null);
   const buttonClickHandler = () => {
@@ -137,33 +126,18 @@ const ChatAiWidget = ({
     }
   }, []);
 
-  assert(
-    applicationId !== null && botId !== null,
-    'applicationId and botId must be provided'
-  );
-
   return (
-    <ConstantStateProvider
-      // If env is not provided, prop will be used instead.
-      // But Either should be provided.
-      applicationId={CHAT_WIDGET_APP_ID ?? applicationId}
-      botId={CHAT_WIDGET_BOT_ID ?? botId}
-      {...constantProps}
-    >
-      <HashedKeyProvider hashedKey={hashedKey ?? null}>
-        <Fragment>
-          <WidgetWindow isOpen={isOpen} setIsOpen={setIsOpen} />
-          <StyledWidgetButtonWrapper onClick={buttonClickHandler}>
-            <StyledWidgetIcon isOpen={isOpen}>
-              <ChatBotIcon />
-            </StyledWidgetIcon>
-            <StyledArrowIcon isOpen={isOpen}>
-              <ArrowDownIcon />
-            </StyledArrowIcon>
-          </StyledWidgetButtonWrapper>
-        </Fragment>
-      </HashedKeyProvider>
-    </ConstantStateProvider>
+    <Fragment>
+      <WidgetWindow isOpen={isOpen} setIsOpen={setIsOpen} {...props} />
+      <StyledWidgetButtonWrapper onClick={buttonClickHandler}>
+        <StyledWidgetIcon isOpen={isOpen}>
+          <ChatBotIcon />
+        </StyledWidgetIcon>
+        <StyledArrowIcon isOpen={isOpen}>
+          <ArrowDownIcon />
+        </StyledArrowIcon>
+      </StyledWidgetButtonWrapper>
+    </Fragment>
   );
 };
 

--- a/src/components/CustomChannel.tsx
+++ b/src/components/CustomChannel.tsx
@@ -8,6 +8,7 @@ import useSendbirdStateContext from '@sendbird/uikit-react/useSendbirdStateConte
 import { useEffect, useState } from 'react';
 
 import { CustomChannelComponent } from './CustomChannelComponent';
+import LoadingScreen from './LoadingScreen';
 import { StartingPage } from './StartingPage';
 import { useConstantState } from '../context/ConstantContext';
 import { useSbConnectionState } from '../context/SBConnectionContext';
@@ -16,6 +17,7 @@ import { useGetBotUser } from '../hooks/useGetBotUser';
 import { assert } from '../utils';
 
 function Channel(props) {
+  const { instantConnect } = useConstantState();
   const { sbConnectionStatus } = useSbConnectionState();
   const { setInitialTimeStamp } = useChannelContext();
   const [channelReady, setChannelReady] = useState(false);
@@ -35,11 +37,15 @@ function Channel(props) {
     return <CustomChannelComponent {...props} />;
   }
 
-  return <StartingPage isStartingPage={true} />;
+  return instantConnect ? (
+    <LoadingScreen />
+  ) : (
+    <StartingPage isStartingPage={true} />
+  );
 }
 
 export default function CustomChannel() {
-  const { botId } = useConstantState();
+  const { botId, instantConnect } = useConstantState();
   const store = useSendbirdStateContext();
   const sb: SendbirdGroupChat = store.stores.sdkStore.sdk as SendbirdGroupChat;
 
@@ -50,6 +56,10 @@ export default function CustomChannel() {
     sb.currentUser,
     botUser
   );
+
+  if (instantConnect && !channel) {
+    return <LoadingScreen />;
+  }
 
   return (
     <ChannelProvider

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -57,7 +57,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
   const startingPagePlaceHolder =
     allMessages.length === 1 && lastMessage.messageType === 'admin';
 
-  const messageMeta = useMemo(() => {
+  const lastMessageMeta = useMemo(() => {
     let messageMeta: MessageMeta | null;
     try {
       messageMeta = lastMessage?.data ? JSON.parse(lastMessage.data) : null;
@@ -112,8 +112,8 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
               {allMessages &&
                 allMessages.length > 1 &&
                 lastMessage.sender.userId === botUser.userId &&
-                !messageMeta?.stream &&
-                isSpecialMessage(
+                !lastMessageMeta?.stream &&
+                !isSpecialMessage(
                   lastMessage.message,
                   suggestedMessageContent.messageFilterList
                 ) && <SuggestedRepliesPanel botUser={botUser} />}

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -18,9 +18,8 @@ import { USER_ID } from '../const';
 import { useConstantState } from '../context/ConstantContext';
 import { isSpecialMessage, scrollUtil } from '../utils';
 
-const Root = styled.div<{ hidePlaceholder: boolean }>`
-  //height: 100vh; // 640px;
-  height: 100%;
+const Root = styled.div<{ hidePlaceholder: boolean; height: string }>`
+  height: ${({ height }) => height};
   font-family: 'Roboto', sans-serif;
   z-index: 0;
   border: none;
@@ -45,7 +44,8 @@ type MessageMeta = {
 
 export function CustomChannelComponent(props: CustomChannelComponentProps) {
   const { botUser, createGroupChannel } = props;
-  const { suggestedMessageContent } = useConstantState();
+  const { suggestedMessageContent, showChatBottom, instantConnect } =
+    useConstantState();
   const { allMessages, currentGroupChannel } = useChannelContext();
 
   const channel: GroupChannel | undefined = currentGroupChannel;
@@ -85,7 +85,10 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
   }, [lastMessage?.messageId]);
 
   return (
-    <Root hidePlaceholder={startingPagePlaceHolder}>
+    <Root
+      hidePlaceholder={startingPagePlaceHolder}
+      height={instantConnect ? '100vh' : '100%'}
+    >
       <ChannelUI
         renderChannelHeader={() => {
           return channel && createGroupChannel ? (
@@ -115,7 +118,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
                   suggestedMessageContent.messageFilterList
                 ) && <SuggestedRepliesPanel botUser={botUser} />}
               <CustomMessageInput />
-              <ChatBottom />
+              {showChatBottom && <ChatBottom />}
             </div>
           );
         }}

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -44,8 +44,7 @@ type MessageMeta = {
 
 export function CustomChannelComponent(props: CustomChannelComponentProps) {
   const { botUser, createGroupChannel } = props;
-  const { suggestedMessageContent, showChatBottom, instantConnect } =
-    useConstantState();
+  const { suggestedMessageContent, instantConnect } = useConstantState();
   const { allMessages, currentGroupChannel } = useChannelContext();
 
   const channel: GroupChannel | undefined = currentGroupChannel;
@@ -118,7 +117,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
                   suggestedMessageContent.messageFilterList
                 ) && <SuggestedRepliesPanel botUser={botUser} />}
               <CustomMessageInput />
-              {showChatBottom && <ChatBottom />}
+              <ChatBottom />
             </div>
           );
         }}

--- a/src/components/CustomChannelHeader.tsx
+++ b/src/components/CustomChannelHeader.tsx
@@ -72,7 +72,7 @@ type Props = {
 
 export default function CustomChannelHeader(props: Props) {
   const { channel, createGroupChannel } = props;
-  const { betaMark } = useConstantState();
+  const { betaMark, customBetaMarkText, instantConnect } = useConstantState();
   const { setFirstMessage } = useSbConnectionState();
 
   function onClickRenewButton() {
@@ -91,15 +91,21 @@ export default function CustomChannelHeader(props: Props) {
           }}
         />
         <Title>{channel.name}</Title>
-        {betaMark && <BetaLogo>{'BETA'}</BetaLogo>}
+        {(betaMark || customBetaMarkText) && (
+          <BetaLogo>{customBetaMarkText}</BetaLogo>
+        )}
       </SubContainer>
       <RenewButtonContainer>
         <RenewButtonForWidgetDemo onClick={onClickRenewButton}>
           <RefreshIcon height="16px" width="16px" />
         </RenewButtonForWidgetDemo>
       </RenewButtonContainer>
-      <EmptyContainer />
-      <EmptyContainer />
+      {!instantConnect && (
+        <>
+          <EmptyContainer />
+          <EmptyContainer />
+        </>
+      )}
     </Root>
   );
 }

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,42 @@
+import styled, { keyframes } from 'styled-components';
+
+import { ReactComponent as SpinIcon } from '../icons/spin-icon.svg';
+
+const spinner = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}`;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  z-index: 100;
+  background-color: white;
+`;
+
+const IconContainer = styled.div`
+  display: grid;
+  justify-content: center;
+  align-items: center;
+  height: 70px;
+  width: 70px;
+  animation: ${spinner} 1.5s linear infinite;
+`;
+
+export default function LoadingScreen() {
+  return (
+    <Container>
+      <IconContainer>
+        <SpinIcon width="50px" height="50px" />
+      </IconContainer>
+    </Container>
+  );
+}

--- a/src/components/StartingPage.tsx
+++ b/src/components/StartingPage.tsx
@@ -145,7 +145,8 @@ interface Props {
 export function StartingPage(props: Props) {
   const { isStartingPage } = props;
   // console.log('## isWebDemo: ', isWebDemo);
-  const { startingPageContent, betaMark, botNickName } = useConstantState();
+  const { startingPageContent, betaMark, customBetaMarkText, botNickName } =
+    useConstantState();
   const {
     sbConnectionStatus,
     setSbConnectionStatus,
@@ -155,7 +156,7 @@ export function StartingPage(props: Props) {
 
   return (
     <Root isStartingPage={isStartingPage}>
-      <BackgroundContainer isStartingPage>
+      <BackgroundContainer>
         <startingPageContent.backGroundContent.Component
           height={startingPageContent?.backGroundContent.height}
         />
@@ -228,8 +229,10 @@ export function StartingPage(props: Props) {
               ? "I'm " + botNickName
               : startingPageContent.headerContent.headerOne}
           </HeaderOne>
-          {betaMark && (
-            <BetaLogo style={{ marginBottom: '3px' }}>{'BETA'}</BetaLogo>
+          {(betaMark || customBetaMarkText) && (
+            <BetaLogo style={{ marginBottom: '3px' }}>
+              {customBetaMarkText}
+            </BetaLogo>
           )}
         </HeaderOneContainer>
         <HeaderTwo>{startingPageContent.headerContent.headerTwo}</HeaderTwo>

--- a/src/components/StartingPage.tsx
+++ b/src/components/StartingPage.tsx
@@ -183,7 +183,7 @@ export function StartingPage(props: Props) {
             <StartMessageBody>
               <StartMessageBodyContent>
                 {startingPageContent.messageContent.body === ''
-                  ? "Hi~ I'm " + botNickName + ' Ask me anything!'
+                  ? `Hi~ I'm ${botNickName}. Ask me anything!`
                   : startingPageContent.messageContent.body}
               </StartMessageBodyContent>
             </StartMessageBody>
@@ -226,7 +226,7 @@ export function StartingPage(props: Props) {
         <HeaderOneContainer style={{ alignItems: 'flex-end' }}>
           <HeaderOne>
             {startingPageContent.headerContent.headerOne === ''
-              ? "I'm " + botNickName
+              ? `I'm ${botNickName}`
               : startingPageContent.headerContent.headerOne}
           </HeaderOne>
           {(betaMark || customBetaMarkText) && (

--- a/src/components/WidgetWindow.tsx
+++ b/src/components/WidgetWindow.tsx
@@ -2,6 +2,7 @@ import { Dispatch, SetStateAction, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import Chat from './Chat';
+import { type Props as ChatWidgetProps } from './ChatAiWidget';
 import { ReactComponent as CloseIcon } from '../icons/ic-widget-close.svg';
 import { ReactComponent as CollapseIcon } from '../icons/icon-collapse.svg';
 import { ReactComponent as ExpandtIcon } from '../icons/icon-expand.svg';
@@ -87,13 +88,16 @@ const StyledCloseButton = styled.button`
   justify-content: center;
 `;
 
+interface WidgetProps {
+  isOpen: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+}
+
 const WidgetWindow = ({
   isOpen,
   setIsOpen,
-}: {
-  isOpen: boolean;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
-}) => {
+  ...props
+}: WidgetProps & ChatWidgetProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   return (
     <StyledWidgetWindowWrapper isOpen={isOpen} isExpanded={isExpanded}>
@@ -103,7 +107,7 @@ const WidgetWindow = ({
       <StyledCloseButton onClick={() => setIsOpen(() => false)}>
         <CloseIcon />
       </StyledCloseButton>
-      <Chat />
+      <Chat {...props} />
     </StyledWidgetWindowWrapper>
   );
 };

--- a/src/const.ts
+++ b/src/const.ts
@@ -41,6 +41,7 @@ export const DEFAULT_CONSTANT: Constant = {
       "That's not a valid question",
       'Is there a specific question you have',
       "I'm here to help you with any questions you have",
+      'Ask away',
     ],
   },
   createGroupChannelParams: {
@@ -79,7 +80,6 @@ export const DEFAULT_CONSTANT: Constant = {
   },
   replacementTextList: [['the Text extracts', 'ChatBot Knowledge Base']],
   instantConnect: false,
-  showChatBottom: true,
 };
 
 export interface Constant {
@@ -94,7 +94,6 @@ export interface Constant {
   messageBottomContent: MessageBottomContent;
   replacementTextList: string[][];
   instantConnect: boolean;
-  showChatBottom: boolean;
 }
 
 export interface SuggestedReply {

--- a/src/const.ts
+++ b/src/const.ts
@@ -11,6 +11,7 @@ export const DEFAULT_CONSTANT: Constant = {
   botNickName: 'Khan Academy Support Bot',
   userNickName: 'User',
   betaMark: true,
+  customBetaMarkText: 'BETA',
   suggestedMessageContent: {
     replyContents: [
       {
@@ -77,18 +78,23 @@ export const DEFAULT_CONSTANT: Constant = {
       'In this beta version, the AI-generated responses may lack complete accuracy.',
   },
   replacementTextList: [['the Text extracts', 'ChatBot Knowledge Base']],
+  instantConnect: false,
+  showChatBottom: true,
 };
 
 export interface Constant {
   botNickName: string;
   userNickName: string;
   betaMark: boolean;
+  customBetaMarkText: string;
   suggestedMessageContent: SuggestedMessageContent;
   createGroupChannelParams: CreateGroupChannelParams;
   startingPageContent: StartingPageContent;
   chatBottomContent: ChatBottomContent;
   messageBottomContent: MessageBottomContent;
   replacementTextList: string[][];
+  instantConnect: boolean;
+  showChatBottom: boolean;
 }
 
 export interface SuggestedReply {

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -39,7 +39,6 @@ export const ConstantStateProvider = (props: ProviderProps) => {
       replacementTextList:
         props.replacementTextList ?? initialState.replacementTextList,
       instantConnect: props.instantConnect ?? initialState.instantConnect,
-      showChatBottom: props.showChatBottom ?? initialState.showChatBottom,
     }),
     [props]
   );

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -24,6 +24,8 @@ export const ConstantStateProvider = (props: ProviderProps) => {
       botNickName: props.botNickName ?? initialState.botNickName,
       userNickName: props.userNickName ?? initialState.userNickName,
       betaMark: props.betaMark ?? initialState.betaMark,
+      customBetaMarkText:
+        props.customBetaMarkText ?? initialState.customBetaMarkText,
       suggestedMessageContent:
         props.suggestedMessageContent ?? initialState.suggestedMessageContent,
       createGroupChannelParams:
@@ -36,6 +38,8 @@ export const ConstantStateProvider = (props: ProviderProps) => {
         props.messageBottomContent ?? initialState.messageBottomContent,
       replacementTextList:
         props.replacementTextList ?? initialState.replacementTextList,
+      instantConnect: props.instantConnect ?? initialState.instantConnect,
+      showChatBottom: props.showChatBottom ?? initialState.showChatBottom,
     }),
     [props]
   );

--- a/src/context/SBConnectionContext.tsx
+++ b/src/context/SBConnectionContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useState, useContext } from 'react';
 
+import { useConstantState } from './ConstantContext';
 import { noop } from '../utils';
 
 type ConnectionStatus = 'INIT' | 'CONNECTING' | 'CONNECTED';
@@ -20,8 +21,10 @@ export const SBConnectionStateContext = createContext<ConstantContextProps>({
 type ProviderProps = React.PropsWithChildren<ConstantContextProps>;
 
 const SBConnectionStateProvider = (props: ProviderProps) => {
+  const { instantConnect } = useConstantState();
   const [sbConnectionStatus, setSbConnectionStatus] =
-    useState<ConnectionStatus>('INIT');
+    // Don't need to use this state if instantConnect is true
+    useState<ConnectionStatus>(instantConnect ? 'CONNECTED' : 'INIT');
   const [firstMessage, setFirstMessage] = useState(null);
 
   return (

--- a/src/hooks/useCreateGroupChannel.ts
+++ b/src/hooks/useCreateGroupChannel.ts
@@ -44,7 +44,7 @@ export function useCreateGroupChannel(
         });
       // We also send the first message to the newly created channel
       // if it has a valid string
-      if (firstMessage !== '' || firstMessage != null) {
+      if (firstMessage !== '' && firstMessage != null) {
         await sendUserMessage(groupChannel, {
           message: firstMessage,
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as ChatAiWidget } from './components/ChatAiWidget';
+export { default as Chat } from './components/Chat';


### PR DESCRIPTION
To use this chat-ai-widget in [web demo](https://github.com/sendbird/ai-bot-url-webdemo), I needed to enable instant connection cause we don't need to delay to do it in our demo website. 

Also, added 2 more new props along with `instantConnect: boolean`
- ~`showChatBottom: boolean`: controls displaying this colorful footer~ Removed this option by addressing this comment https://github.com/sendbird/chat-ai-widget/pull/17#discussion_r1273065983
<img width="422" alt="Screenshot 2023-07-25 at 1 56 47 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/eabad5cd-d8d7-4983-b02d-87b8a9a82e5a">

- `customBetaMarkText: string`: controls displaying the text in this tag
<img width="56" alt="Screenshot 2023-07-25 at 1 57 12 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/5bbb82cd-69d7-45df-a6b8-f59c8ee0f16f">





Here's how it looks in webdemo (I published 1.0.3-rc to test this out) with the new props 
```
instantConnect: true,
showChatBottom: false,
customBetaMarkText: 'DEMO'
```
<img width="500" alt="Screenshot 2023-07-25 at 2 28 20 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/ae8094ad-163a-472e-b5cc-9b540e82737d">



