### PR TITLE
Fix pending after first message

### DIFF
--- a/src/hooks/useCreateGroupChannel.ts
+++ b/src/hooks/useCreateGroupChannel.ts
@@ -12,6 +12,19 @@ import { useConstantState } from '../context/ConstantContext';
 import { useSbConnectionState } from '../context/SBConnectionContext';
 import { delay } from '../utils';
 
+async function waitForLastMessage(
+  channel: GroupChannel,
+  maxRetries = 30,
+  retryInterval = 100
+) {
+  let count = 0;
+  while (channel.lastMessage == null && count < maxRetries) {
+    await delay(retryInterval);
+    count++;
+  }
+  await delay(500);
+}
+
 export function useCreateGroupChannel(
   currentUser: User | null,
   botUser: User
@@ -49,12 +62,7 @@ export function useCreateGroupChannel(
           message: firstMessage,
         });
       }
-      let count = 0;
-      while (groupChannel.lastMessage == null && count < 30) {
-        await delay(100);
-        count += 1;
-      }
-      await delay(500);
+      await waitForLastMessage(groupChannel);
     } catch (error) {
       console.error(error);
     } finally {

--- a/src/hooks/useCreateGroupChannel.ts
+++ b/src/hooks/useCreateGroupChannel.ts
@@ -49,8 +49,12 @@ export function useCreateGroupChannel(
           message: firstMessage,
         });
       }
-      // let's wait for a second to make sure channel is created & ready
-      await delay(1000);
+      let count = 0;
+      while (groupChannel.lastMessage == null && count < 30) {
+        await delay(100);
+        count += 1;
+      }
+      await delay(500);
     } catch (error) {
       console.error(error);
     } finally {


### PR DESCRIPTION
### Details
Add detailed waiting logic for the issue that Bot's message is pending after sending the first message

### How to
Add logic to wait until the last message to the group channel is not null (up to 3 seconds) because it determines that an error occurs when the channel loads immediately after sending a message to the group channel