### PR TITLE
feat: add customRefreshComponent prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ const App = () => {
       chatBottomContent={customConstants.chatBottomContent}
       messageBottomContent={customConstants.messageBottomContent}
       replacementTextList={customConstants.replacementTextList}
+      customRefreshComponent={customConstants.customRefreshComponent}
     />
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ const App = (props: Props) => {
       replacementTextList={props.replacementTextList}
       hashedKey={props.hashedKey}
       instantConnect={props.instantConnect}
+      customRefreshComponent={props.customRefreshComponent}
     />
   );
 };

--- a/src/components/CustomChannelHeader.tsx
+++ b/src/components/CustomChannelHeader.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { useConstantState } from '../context/ConstantContext';
 import { useSbConnectionState } from '../context/SBConnectionContext';
 import channelHeaderImage from '../icons/bot-message-image.png';
-import { ReactComponent as RefreshIcon } from '../icons/refresh-icon.svg';
 
 const Root = styled.div`
   display: flex;
@@ -60,11 +59,6 @@ const BetaLogo = styled.div`
   letter-spacing: 0.8px;
 `;
 
-const EmptyContainer = styled.div`
-  width: 24px;
-  height: 24px;
-`;
-
 type Props = {
   channel: GroupChannel;
   createGroupChannel: () => void;
@@ -72,14 +66,17 @@ type Props = {
 
 export default function CustomChannelHeader(props: Props) {
   const { channel, createGroupChannel } = props;
-  const { betaMark, customBetaMarkText, instantConnect } = useConstantState();
+  const { betaMark, customBetaMarkText, customRefreshComponent } =
+    useConstantState();
   const { setFirstMessage } = useSbConnectionState();
 
   function onClickRenewButton() {
     setFirstMessage(null);
     createGroupChannel();
+    customRefreshComponent?.onClick?.();
     // window.location.reload();
   }
+
   return (
     <Root>
       <SubContainer>
@@ -97,15 +94,13 @@ export default function CustomChannelHeader(props: Props) {
       </SubContainer>
       <RenewButtonContainer>
         <RenewButtonForWidgetDemo onClick={onClickRenewButton}>
-          <RefreshIcon height="16px" width="16px" />
+          <customRefreshComponent.icon
+            width={customRefreshComponent.width}
+            height={customRefreshComponent.height}
+            style={customRefreshComponent.style}
+          />
         </RenewButtonForWidgetDemo>
       </RenewButtonContainer>
-      {!instantConnect && (
-        <>
-          <EmptyContainer />
-          <EmptyContainer />
-        </>
-      )}
     </Root>
   );
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { ReactComponent as StartingPageLogo } from './icons/icon-widget-chatbot.svg';
+import { ReactComponent as RefreshIcon } from './icons/refresh-icon.svg';
 import { ReactComponent as StartingPageBackground } from './icons/starting-page-bg-image-svg.svg';
-import { uuid } from './utils';
+import { noop, uuid } from './utils';
 
 export const USER_ID = uuid();
 // get your app_id -> https://dashboard.sendbird.com/auth/signin
@@ -80,6 +81,17 @@ export const DEFAULT_CONSTANT: Constant = {
   },
   replacementTextList: [['the Text extracts', 'ChatBot Knowledge Base']],
   instantConnect: false,
+  customRefreshComponent: {
+    icon: RefreshIcon,
+    width: '16px',
+    height: '16px',
+    style: {
+      position: 'relative',
+      // FIXME: This is a hack to make the refresh icon appear next to the expand & close icons in the widget window
+      right: '60px',
+    },
+    onClick: noop,
+  },
 };
 
 export interface Constant {
@@ -94,6 +106,7 @@ export interface Constant {
   messageBottomContent: MessageBottomContent;
   replacementTextList: string[][];
   instantConnect: boolean;
+  customRefreshComponent: CustomRefreshComponent;
 }
 
 export interface SuggestedReply {
@@ -153,4 +166,12 @@ export interface StartingMessageContent {
 export interface MessageBottomContent {
   text: string;
   infoIconText: string;
+}
+
+export interface CustomRefreshComponent {
+  icon: React.FC;
+  width: string;
+  height: string;
+  onClick?: () => void;
+  style?: React.CSSProperties;
 }

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -39,6 +39,24 @@ export const ConstantStateProvider = (props: ProviderProps) => {
       replacementTextList:
         props.replacementTextList ?? initialState.replacementTextList,
       instantConnect: props.instantConnect ?? initialState.instantConnect,
+      customRefreshComponent: {
+        icon:
+          props.customRefreshComponent?.icon ??
+          initialState.customRefreshComponent.icon,
+        width:
+          props.customRefreshComponent?.width ??
+          initialState.customRefreshComponent.width,
+        height:
+          props.customRefreshComponent?.height ??
+          initialState.customRefreshComponent.height,
+        onClick:
+          props.customRefreshComponent?.onClick ??
+          initialState.customRefreshComponent.onClick,
+        style: {
+          ...initialState.customRefreshComponent.style,
+          ...props.customRefreshComponent?.style,
+        },
+      },
     }),
     [props]
   );


### PR DESCRIPTION
### What's the issue?
1. Currently, the refresh icon and the expand + close icons are placed separately, making it difficult to control them neatly. As a result, we use `<EmptyContainer />` to avoid overlapping the refresh icon with the close icon.
2. There's currently no way to handle the refresh icon from outside of the ChatWidget component.

### How I solved it:
1. Removed the EmptyContainer that was previously positioned next to the refresh icon.
2. Introduced a new prop: `customRefreshComponent`, which allows the chat-ai-widget user to control the refresh icon by providing their own custom icon component.

```typescript
export interface CustomRefreshComponent {
  icon: React.FC;
  width: string;
  height: string;
  onClick?: () => void;
  style?: React.CSSProperties;
}
```
#### AS-IS

<img src="https://github.com/sendbird/chat-ai-widget/assets/10060731/9acf10eb-aaed-44c7-8025-767ad5d29091" width="500" />

#### TO-BE
<img src="https://github.com/sendbird/chat-ai-widget/assets/10060731/e7ef1274-867f-4c9a-850e-17486b008ced" width="500" />

