### PR TITLE
feat: give scrollMarginBotton if suggested reply is displayed

### DIFF
--- a/src/hooks/useScrollOnStreaming.ts
+++ b/src/hooks/useScrollOnStreaming.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+
+import { useThrottle } from '../hooks/useThrottle';
+
+interface Params {
+  isLastBotMessage: boolean;
+  lastMessageRef: React.RefObject<HTMLDivElement>;
+  bottomBuffer: number;
+}
+export function useScrollOnStreaming({
+  isLastBotMessage,
+  lastMessageRef,
+  bottomBuffer,
+}: Params) {
+  const throttledScrollIntoView = useThrottle((element: HTMLDivElement) => {
+    element.scrollIntoView({ block: 'end', behavior: 'smooth' });
+    if (bottomBuffer > 0) {
+      element.style.scrollMarginBottom = `${bottomBuffer}px`;
+    }
+  }, 30);
+
+  useEffect(() => {
+    const observer = new ResizeObserver((entries) => {
+      entries.forEach(() => {
+        try {
+          if (lastMessageRef?.current) {
+            throttledScrollIntoView(lastMessageRef.current);
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      });
+    });
+    if (isLastBotMessage && lastMessageRef?.current) {
+      const targetNode = lastMessageRef?.current;
+      // create mutation observer
+      observer.observe(targetNode);
+    }
+    return () => {
+      observer.disconnect();
+    };
+  }, [isLastBotMessage, bottomBuffer]);
+}


### PR DESCRIPTION
Fixes https://sendbird.atlassian.net/browse/AC-245

### What's the issue?
When streaming reply is on, we keep scrolling down and down until the last message from the bot ends. 
However, when the streaming is done, the suggested reply panel is displayed at the bottom, overlapping the last message like this:
<img width="380" alt="Screenshot 2023-07-28 at 4 14 53 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/007ab9fd-439a-4677-a09b-bb8bf46501c8">


### How I solved?
1. Added 50px of buffer to be scrolled down a bit more when displaying the suggested reply panel.
2. The panel height is about 50px, so this buffer ensures the suggested reply panel does not overlap the last message.


With this fix, it'll be working like this:
<img width="380" alt="Screenshot 2023-07-28 at 4 11 19 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/c93d2b42-c4c1-4fc6-9c13-4c0d33ba0e16">

