### PR TITLE
feat: add configureSession & userId prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ const customConstants = {
   applicationId: 'AE8F7EEA-4555-4F86-AD8B-5E0BD86BFE67', // Your Sendbird application ID
   botId: 'khan-academy-bot', // Your Sendbird bot ID
   botNickName: 'Khan Academy Support Bot',
+  userId: 'user1', // Specify your userId. If it's not provided, it'll generate a random one \w uuid
   userNickName: 'User',
   betaMark: true,
   suggestedMessageContent: {
@@ -174,6 +175,7 @@ const App = () => {
       applicationId={customConstants.applicationId}
       botId={customConstants.botId}
       botNickName={customConstants.botNickName}
+      userId={customConstants.userId}
       userNickName={customConstants.userNickName}
       betaMark={customConstants.betaMark}
       customBetaMarkText={customConstants.customBetaMarkText}

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ https://sendbird.github.io/chat-ai-widget/
 After your chatbot has been created, you can start testing conversations directly from the web interface.
 <img width="800" alt="image" src="https://github.com/sf-luke-cha/ai-chatbot-tutorial/assets/104121286/f1d39df3-b50a-4c6d-a419-ef4bca5dcb87">
 
-## Customization
+## Basic Customization
 You can customize the UI of the ChatBot by using the `ChatAiWidget` component. The following are the props that can be used to customize the UI.
 
 ```jsx
@@ -93,6 +93,7 @@ import '@sendbird/chat-ai-widget/dist/style.css';
 
 import { ReactComponent as StartingPageLogo } from './icons/sendbird-logo-starting-page.svg';
 import { ReactComponent as StartingPageBackground } from './icons/starting-page-bg-image-svg.svg';
+
 
 const customConstants = {
   applicationId: 'AE8F7EEA-4555-4F86-AD8B-5E0BD86BFE67', // Your Sendbird application ID
@@ -185,11 +186,90 @@ const App = () => {
       chatBottomContent={customConstants.chatBottomContent}
       messageBottomContent={customConstants.messageBottomContent}
       replacementTextList={customConstants.replacementTextList}
-      customRefreshComponent={customConstants.customRefreshComponent}
     />
   );
 };
 
 export default App;
 
+```
+
+## Advanced Customization
+```jsx
+import { ChatAiWidget } from "@sendbird/chat-ai-widget";
+import '@sendbird/chat-ai-widget/dist/style.css';
+
+import { SessionHandler } from '@sendbird/chat'
+
+// Replace below with the real one
+const USER_ID = 'UserId';
+
+/**
+ * To setup auth on their own API,
+ * You can also create your own custom session handler \w userId.
+ * More information can be found in
+ * https://sendbird.com/docs/chat/v3/javascript/guides/authentication
+ * Also, we recommend to memoize this configureSession function,
+ * before you pass to ChatAiWidget component.
+ * */
+const issueSessionToken = async (userId, ...) => {
+  // build your own API request handler
+};
+
+const memoizedConfigureSession = useCallback(
+  (sdk) => {
+    const sessionHandler = new SessionHandler();
+    sessionHandler.onSessionTokenRequired = (resolve, reject) => {
+      console.warn('SessionHandler.onSessionTokenRequired()');
+      // This issueSessionToken fn i
+      issueSessionToken(USER_ID)
+        .then(token => {
+          // curentUserInfo.accessToken = token;
+          resolve(token);
+        })
+        .catch(err => reject(err));
+    };
+    sessionHandler.onSessionRefreshed = () => {
+      console.warn('SessionHandler.onSessionRefreshed()');
+    };
+    sessionHandler.onSessionError = (err) => {
+      console.warn('SessionHandler.onSessionError()', err);
+    };
+    sessionHandler.onSessionClosed = () => {
+      console.warn('SessionHandler.onSessionClosed()');
+    };
+    console.warn(sessionHandler);
+    return sessionHandler;
+  },[]);
+
+const customConfigs = {
+  configureSession: memoizedConfigureSession,
+  customRefreshComponent: {
+    icon: 'Your SVG icon',
+    style: {
+      position: 'relative' as React.CSSProperties['position'],
+      right: 0,
+    },
+    width: '16px',
+    height: '16px',
+    onClick: () => { ... },
+  }
+}
+
+const customConstants = {
+  // Add other constant props like in the basic customization section above
+}
+
+const App = () => {
+  return (
+    <ChatAiWidget
+      userId={USER_ID}
+      configureSession={customConfigs.configureSession}
+      customRefreshComponent={customConfigs.customRefreshComponent}
+      {...customConstants}
+    />
+  );
+};
+
+export default App;
 ```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const App = (props: Props) => {
       hashedKey={props.hashedKey}
       instantConnect={props.instantConnect}
       customRefreshComponent={props.customRefreshComponent}
+      configureSession={props.configureSession}
     />
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ const App = (props: Props) => {
       applicationId={props.applicationId}
       botId={props.botId}
       botNickName={props.botNickName}
+      userId={props.userId}
       userNickName={props.userNickName}
       betaMark={props.betaMark}
       customBetaMarkText={props.customBetaMarkText}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -6,7 +6,6 @@ import { useMemo } from 'react';
 import { type Props as ChatWidgetProps } from './ChatAiWidget';
 import CustomChannel from './CustomChannel';
 import { StartingPage } from './StartingPage';
-import { USER_ID } from '../const';
 import {
   useConstantState,
   ConstantStateProvider,
@@ -18,7 +17,7 @@ import SBConnectionStateProvider, {
 import { assert } from '../utils';
 
 const SBComponent = () => {
-  const { applicationId, botId, userNickName } = useConstantState();
+  const { applicationId, botId, userId, userNickName } = useConstantState();
 
   assert(
     applicationId !== null && botId !== null,
@@ -44,7 +43,7 @@ const SBComponent = () => {
   return (
     <SBProvider
       appId={applicationId}
-      userId={USER_ID}
+      userId={userId}
       nickname={userNickName}
       customApiHost={`https://api-${applicationId}.sendbird.com`}
       customWebSocketHost={`wss://ws-${applicationId}.sendbird.com`}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -17,7 +17,8 @@ import SBConnectionStateProvider, {
 import { assert } from '../utils';
 
 const SBComponent = () => {
-  const { applicationId, botId, userId, userNickName } = useConstantState();
+  const { applicationId, botId, userId, userNickName, configureSession } =
+    useConstantState();
 
   assert(
     applicationId !== null && botId !== null,
@@ -48,6 +49,7 @@ const SBComponent = () => {
       customApiHost={`https://api-${applicationId}.sendbird.com`}
       customWebSocketHost={`wss://ws-${applicationId}.sendbird.com`}
       sdkInitParams={sdkInitParams}
+      configureSession={configureSession}
     >
       <>
         <CustomChannel />

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -14,7 +14,6 @@ import CustomChannelHeader from './CustomChannelHeader';
 import CustomMessage from './CustomMessage';
 import CustomMessageInput from './CustomMessageInput';
 import SuggestedRepliesPanel from './SuggestedRepliesPanel';
-import { USER_ID } from '../const';
 import { useConstantState } from '../context/ConstantContext';
 import { useScrollOnStreaming } from '../hooks/useScrollOnStreaming';
 import { isSpecialMessage, scrollUtil } from '../utils';
@@ -45,7 +44,8 @@ type MessageMeta = {
 
 export function CustomChannelComponent(props: CustomChannelComponentProps) {
   const { botUser, createGroupChannel } = props;
-  const { suggestedMessageContent, instantConnect } = useConstantState();
+  const { userId, suggestedMessageContent, instantConnect } =
+    useConstantState();
   const { allMessages, currentGroupChannel } = useChannelContext();
   const lastMessageRef = useRef<HTMLDivElement>(null);
 
@@ -95,7 +95,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
   useEffect(() => {
     if (
       lastMessage &&
-      lastMessage.sender?.userId === USER_ID &&
+      lastMessage.sender?.userId === userId &&
       lastMessage.sendingStatus === SendingStatus.SUCCEEDED
     ) {
       setActiveSpinnerId(lastMessage.messageId);

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,3 +1,6 @@
+import SendbirdChat, { SessionHandler } from '@sendbird/chat';
+import { type SendbirdGroupChat } from '@sendbird/chat/groupChannel';
+import { type SendbirdOpenChat } from '@sendbird/chat/openChannel';
 import React from 'react';
 
 import { ReactComponent as StartingPageLogo } from './icons/icon-widget-chatbot.svg';
@@ -95,6 +98,10 @@ export const DEFAULT_CONSTANT: Constant = {
   },
 };
 
+type ConfigureSession = (
+  sdk: SendbirdChat | SendbirdGroupChat | SendbirdOpenChat
+) => SessionHandler;
+
 export interface Constant {
   botNickName: string;
   userId: string;
@@ -109,6 +116,7 @@ export interface Constant {
   replacementTextList: string[][];
   instantConnect: boolean;
   customRefreshComponent: CustomRefreshComponent;
+  configureSession: ConfigureSession;
 }
 
 export interface SuggestedReply {

--- a/src/const.ts
+++ b/src/const.ts
@@ -5,11 +5,12 @@ import { ReactComponent as RefreshIcon } from './icons/refresh-icon.svg';
 import { ReactComponent as StartingPageBackground } from './icons/starting-page-bg-image-svg.svg';
 import { noop, uuid } from './utils';
 
-export const USER_ID = uuid();
+const USER_ID = uuid();
 // get your app_id -> https://dashboard.sendbird.com/auth/signin
 
 export const DEFAULT_CONSTANT: Constant = {
   botNickName: 'Khan Academy Support Bot',
+  userId: USER_ID,
   userNickName: 'User',
   betaMark: true,
   customBetaMarkText: 'BETA',
@@ -96,6 +97,7 @@ export const DEFAULT_CONSTANT: Constant = {
 
 export interface Constant {
   botNickName: string;
+  userId: string;
   userNickName: string;
   betaMark: boolean;
   customBetaMarkText: string;

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -22,6 +22,7 @@ export const ConstantStateProvider = (props: ProviderProps) => {
       applicationId: props.applicationId,
       botId: props.botId,
       botNickName: props.botNickName ?? initialState.botNickName,
+      userId: props.userId ?? initialState.userId,
       userNickName: props.userNickName ?? initialState.userNickName,
       betaMark: props.betaMark ?? initialState.betaMark,
       customBetaMarkText:

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -58,6 +58,7 @@ export const ConstantStateProvider = (props: ProviderProps) => {
           ...props.customRefreshComponent?.style,
         },
       },
+      configureSession: props.configureSession,
     }),
     [props]
   );


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-252


### What's the request? 
Open an interface that allows users to pass their own custom session handler. 

### How I handled it?
I've added new props, `configureSession` and `userId`, which can be passed into the `<SendbirdProvider />` component.
