### PR TITLE
feat: apply lazy loading for CodeBlock

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,16 @@
+// Ref: https://github.com/rajinwonderland/react-code-blocks#-demo
+import { CopyBlock as Component, irBlack } from 'react-code-blocks';
+
+import { Token } from '../utils';
+
+export function CodeBlock({ token }: { token: Token }) {
+  return (
+    <Component
+      text={token.value}
+      language={token.type}
+      theme={irBlack}
+      showLineNumbers={true}
+      codeBlock
+    />
+  );
+}

--- a/src/components/ParsedBotMessageBody.tsx
+++ b/src/components/ParsedBotMessageBody.tsx
@@ -1,11 +1,15 @@
 // Ref: https://github.com/rajinwonderland/react-code-blocks#-demo
 import { UserMessage } from '@sendbird/chat/message';
-import { CopyBlock, irBlack } from 'react-code-blocks';
+import { lazy, Suspense } from 'react';
 import styled from 'styled-components';
 
 import BotMessageBottom from './BotMessageBottom';
 import SourceContainer, { Source } from './SourceContainer';
 import { Token, TokenType } from '../utils';
+
+const LazyCodeBlock = lazy(() =>
+  import('./CodeBlock').then(({ CodeBlock }) => ({ default: CodeBlock }))
+);
 
 const Root = styled.div`
   display: flex;
@@ -69,13 +73,9 @@ export default function ParsedBotMessageBody(props: Props) {
           }
           return (
             <BlockContainer key={'token' + i}>
-              <CopyBlock
-                text={token.value}
-                language={token.type}
-                theme={irBlack}
-                showLineNumbers={true}
-                codeBlock
-              />
+              <Suspense fallback={<></>}>
+                <LazyCodeBlock token={token} />
+              </Suspense>
             </BlockContainer>
           );
         })}


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-259 

### What's the issue?
One of our users reported an issue where the chat AI widget takes some time to load the `react-code-blocks` library during initialization. 
This delay is due to the relatively large bundle size of `react-code-blocks`, and it appears that the library isn't loaded until it's required, i.e. when a message contains a code block format

### How did I solve it?
Addressed a lazy loading for the `<CodeBlock />` component by separating it from `<ParsedBotMessageBody />`.
Now, the `react-code-blocks` library is loaded only when necessary, resulting in a more efficient and faster loading process for the chat AI widget.

It also creates a separate bundle like this.
<img width="508" alt="Screenshot 2023-08-01 at 3 56 27 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/6999eaee-1206-48c7-8528-2d9e7a98361d">
