### PR TITLE
ci/cd: add pr-comment-bot workflow for release ticket creation

### DIFF
--- a/.github/workflows/pr-comment-bot.yml
+++ b/.github/workflows/pr-comment-bot.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # see list of commands: https://github.com/sendbird/release-automation-action#commands
-      - uses: sendbird/release-automation-action@0.0.3
+      - uses: sendbird/release-automation-action@latest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           circleci_token: ${{ secrets.CIRCLECI_API_TOKEN }}

--- a/.github/workflows/pr-comment-bot.yml
+++ b/.github/workflows/pr-comment-bot.yml
@@ -1,0 +1,19 @@
+name: PR comment bot
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  pr-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # see list of commands: https://github.com/sendbird/release-automation-action#commands
+      - uses: sendbird/release-automation-action@0.0.3
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          circleci_token: ${{ secrets.CIRCLECI_API_TOKEN }}
+          product: 'chat-ai-widget'
+          platform: 'js'
+          framework: 'react'
+          product_jira_project_key: 'AC'
+          product_jira_version_prefix: 'js_chat_ai_widget'

--- a/release-guide.md
+++ b/release-guide.md
@@ -4,6 +4,7 @@
 1. Create a new branch for the release: e.g. `git checkout -b release/{X.X.X}`
 2. Write/Generate changelog in CHANGELOG.md
 3. Commit all changes, push to remote
+4. Comment `/bot create ticket` on github PR to make release ticket automatically
 
 ## Step 1 - Release Candidate
 1. Update the version in `package.json`: e.g. `version: {version}-rc-0` (increase the number if it's necessary)


### PR DESCRIPTION
Added a github actions workflow for release Jira ticket creation. 
Here's an example how it works https://github.com/sendbird/sendbird-uikit-react/pull/694#issuecomment-1645003770. 

