### PR TITLE
feat: pass customExtensionParams to SBProvider for logging purpose

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.0.1",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/chat-ai-widget",
-      "version": "1.0.1",
+      "version": "1.0.5",
       "dependencies": {
-        "@sendbird/chat": "^4.9.3",
-        "@sendbird/uikit-react": "3.6.5",
+        "@sendbird/chat": "^4.9.7",
+        "@sendbird/uikit-react": "^3.6.6",
         "dompurify": "^3.0.4",
         "polished": "^2.3.1",
         "react-code-blocks": "^0.1.0",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@sendbird/chat": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.9.3.tgz",
-      "integrity": "sha512-TvK32c8L54QedDrdshA/tKgv9UJUfKXDPADIu0IORrfsWKqp3X4bqYTb40IYSX31v6ksK8rbJTofz3y3bUVSRg==",
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.9.7.tgz",
+      "integrity": "sha512-VNipPeJT7B6hD/OBDi6IjcGW+Y8fJHNkVUkvFk0BUkkZLY1eefUmtrv2CWWbJ0hxfGFWe+wRVEjsdWDXqLN/DA==",
       "peerDependencies": {
         "@react-native-async-storage/async-storage": "^1.17.6"
       },
@@ -1032,11 +1032,11 @@
       }
     },
     "node_modules/@sendbird/uikit-react": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/@sendbird/uikit-react/-/uikit-react-3.6.5.tgz",
-      "integrity": "sha512-5SCy8xklAGDEepG7wcJ/uU2meXPUV4w2cprG4bsX7T+vE09AuI9BDlXwa4lCesuK3l6cH88r8YIaCfJ9ZRqqeQ==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@sendbird/uikit-react/-/uikit-react-3.6.6.tgz",
+      "integrity": "sha512-t94O1LeWD+MfgRZ7LxffXJCA6gWeAzaap4r/jg1P8ImmR/8srftun0rnBPUnFbdBPe5eWXSai1qcTSjSEen2nw==",
       "dependencies": {
-        "@sendbird/chat": "^4.9.2",
+        "@sendbird/chat": "^4.9.6",
         "@sendbird/uikit-tools": "0.0.1-alpha.40",
         "css-vars-ponyfill": "^2.3.2",
         "date-fns": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@sendbird/chat": "^4.9.3",
-    "@sendbird/uikit-react": "3.6.5",
+    "@sendbird/chat": "^4.9.7",
+    "@sendbird/uikit-react": "^3.6.6",
     "dompurify": "^3.0.4",
     "polished": "^2.3.1",
     "react-code-blocks": "^0.1.0",

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,7 +1,7 @@
 import '@sendbird/uikit-react/dist/index.css';
 import '../css/index.css';
 import SBProvider from '@sendbird/uikit-react/SendbirdProvider';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 
 import { type Props as ChatWidgetProps } from './ChatAiWidget';
 import CustomChannel from './CustomChannel';
@@ -32,6 +32,8 @@ const SBComponent = () => {
     []
   );
 
+  const userAgentCustomParams = useRef({ 'chat-ai-widget': 'True' });
+
   // Until the user sends a first message,
   // we will display a fake channel UI not to establish a connection to Sendbird Chat SDK
   // `sbConnectionStatus` will be changed to `CONNECTING` after the first message is sent
@@ -50,6 +52,7 @@ const SBComponent = () => {
       customWebSocketHost={`wss://ws-${applicationId}.sendbird.com`}
       sdkInitParams={sdkInitParams}
       configureSession={configureSession}
+      customExtensionParams={userAgentCustomParams.current}
     >
       <>
         <CustomChannel />


### PR DESCRIPTION
Passed `customExtensionParams` which has been added by https://github.com/sendbird/sendbird-uikit-react/pull/698 in React UIKit. I bumped up the uikit version as well to achieve this.
