### PR TITLE
fix: prevent parent element's scrolling

### DIFF
--- a/src/hooks/useScrollOnStreaming.ts
+++ b/src/hooks/useScrollOnStreaming.ts
@@ -13,7 +13,7 @@ export function useScrollOnStreaming({
   bottomBuffer,
 }: Params) {
   const throttledScrollIntoView = useThrottle((element: HTMLDivElement) => {
-    element.scrollIntoView({ block: 'end', behavior: 'smooth' });
+    element.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     if (bottomBuffer > 0) {
       element.style.scrollMarginBottom = `${bottomBuffer}px`;
     }


### PR DESCRIPTION
Aims to fix https://sendbird.atlassian.net/browse/AC-300

### What's the issue?
https://github.com/sendbird/chat-ai-widget/assets/10060731/f24be35a-cffb-41e3-8a2e-f2bf28a04aaf


### How I tried to solve it?
Just changed the option value of `scrollIntoView({ block: 'end' })` to `scrollIntoView({ block: 'nearest' })`. 
Here's the different of each.

 - `block: 'end'`: When set to "end", the element is scrolled so that its end (bottom edge) aligns with the end of the scroll container. However, using this option might not only move the targeted element to the end but could also affect the scrolling of the entire parent container. This behavior might lead to unexpected scrolling of the parent container.
 - `block: 'nearest'`: On the other hand, when set to "nearest", the element is scrolled so that it aligns with the nearest edge of the scroll container. Typically, this means that the visible portion of the element aligns with the visible portion of the container. This option is often preferred when you want to bring an element into view without causing excessive scrolling of the parent container.
 
 
 So, not sure this is gonna completely resolve the issue but probably reduce the possibility. 