### PR TITLE
Handle AdminMessage Errors & Add Source Message option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ const customConstants = {
       'In this beta version, the AI-generated responses may lack complete accuracy.',
   },
   replacementTextList: [['the Text extracts', 'ChatBot Knowledge Base']],
+  enableSourceMessage: false,
 };
 
 const App = () => {
@@ -186,6 +187,7 @@ const App = () => {
       chatBottomContent={customConstants.chatBottomContent}
       messageBottomContent={customConstants.messageBottomContent}
       replacementTextList={customConstants.replacementTextList}
+      enableSourceMessage={customConstants.enableSourceMessage}
     />
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const App = (props: Props) => {
       instantConnect={props.instantConnect}
       customRefreshComponent={props.customRefreshComponent}
       configureSession={props.configureSession}
+      enableSourceMessage={props.enableSourceMessage}
     />
   );
 };

--- a/src/components/AdminMessage.tsx
+++ b/src/components/AdminMessage.tsx
@@ -1,0 +1,56 @@
+import { UserMessage } from '@sendbird/chat/message';
+import styled from 'styled-components';
+
+const Root = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: end;
+  margin-bottom: 6px;
+  flex-wrap: wrap-reverse;
+  gap: 8px;
+`;
+
+const BodyContainer = styled.div`
+  max-width: calc(100% - 90px); // 600px;
+  font-size: 11px;
+  width: fit-content;
+  font-weight: normal;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: 1.43;
+  letter-spacing: normal;
+`;
+
+const BodyComponent = styled.div`
+  color: #808080;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 8px 12px;
+  gap: 12px;
+  border-radius: 16px;
+  white-space: pre-wrap;
+`;
+
+const TextComponent = styled.div`
+  white-space: pre-line;
+`;
+
+type Props = {
+  message: UserMessage;
+};
+
+export default function AdminMessage(props: Props) {
+  const { message } = props;
+
+  return (
+    <Root>
+      <BodyContainer>
+        <BodyComponent>
+          <TextComponent>{message.message}</TextComponent>
+        </BodyComponent>
+      </BodyContainer>
+    </Root>
+  );
+}

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -54,6 +54,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
     allMessages?.length - 1
   ] as ClientUserMessage;
   const isLastBotMessage =
+    !(lastMessage?.messageType === 'admin') &&
     (lastMessage as ClientUserMessage)?.sender.userId === botUser.userId;
 
   const [activeSpinnerId, setActiveSpinnerId] = useState(-1);

--- a/src/components/CustomMessage.tsx
+++ b/src/components/CustomMessage.tsx
@@ -4,6 +4,7 @@ import { useChannelContext } from '@sendbird/uikit-react/Channel/context';
 // eslint-disable-next-line import/no-unresolved
 import { EveryMessage } from 'SendbirdUIKitGlobal';
 
+import AdminMessage from './AdminMessage';
 import BotMessageWithBodyInput from './BotMessageWithBodyInput';
 import CurrentUserMessage from './CurrentUserMessage';
 import CustomMessageBody from './CustomMessageBody';
@@ -34,6 +35,11 @@ export default function CustomMessage(props: Props) {
   const { allMessages } = useChannelContext();
   const firstMessage: UserMessage = allMessages[0] as UserMessage;
   const firstMessageId = firstMessage?.messageId ?? -1;
+
+  // admin message
+  if (message.messageType === 'admin') {
+    return <div>{<AdminMessage message={message} />}</div>;
+  }
 
   // Sent by current user
   if ((message as UserMessage).sender.userId !== botUser.userId) {

--- a/src/components/ParsedBotMessageBody.tsx
+++ b/src/components/ParsedBotMessageBody.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import BotMessageBottom from './BotMessageBottom';
 import SourceContainer, { Source } from './SourceContainer';
+import { useConstantState } from '../context/ConstantContext';
 import { Token, TokenType } from '../utils';
 
 const LazyCodeBlock = lazy(() =>
@@ -52,6 +53,7 @@ type MetaData = {
  */
 export default function ParsedBotMessageBody(props: Props) {
   const { message, tokens } = props;
+  const { enableSourceMessage } = useConstantState();
   const data_ = (message as UserMessage).data as string;
   const data: MetaData = JSON.parse(data_);
   const sources: Source[] = Array.isArray(data['metadatas'])
@@ -59,7 +61,7 @@ export default function ParsedBotMessageBody(props: Props) {
     : [];
 
   // console.log('## sources: ', sources);
-  if (tokens.length > 0) {
+  if (tokens.length > 0 && enableSourceMessage) {
     return (
       <Root>
         {tokens.map((token: Token, i) => {

--- a/src/const.ts
+++ b/src/const.ts
@@ -96,6 +96,7 @@ export const DEFAULT_CONSTANT: Constant = {
     },
     onClick: noop,
   },
+  enableSourceMessage: true,
 };
 
 type ConfigureSession = (
@@ -117,6 +118,7 @@ export interface Constant {
   instantConnect: boolean;
   customRefreshComponent: CustomRefreshComponent;
   configureSession: ConfigureSession;
+  enableSourceMessage: boolean;
 }
 
 export interface SuggestedReply {

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -59,6 +59,8 @@ export const ConstantStateProvider = (props: ProviderProps) => {
         },
       },
       configureSession: props.configureSession,
+      enableSourceMessage:
+        props.enableSourceMessage ?? initialState.enableSourceMessage,
     }),
     [props]
   );


### PR DESCRIPTION
### Changes:

Slack: https://sendbird.slack.com/archives/C0585965FFA/p1691483598104379
![image](https://github.com/sendbird/chat-ai-widget/assets/104121286/3825db57-d59e-40fe-abdb-99821f0469f2)


1. **AdminMessage Bugfix**: 
   - Resolved issues causing errors when receiving an `AdminMessage`.

2. **Source Message**: 
   - Add an option `enableSourceMessage` to show/hide the Source area .
   - Default setting is `true`.