### PR TITLE
fix: add firstMessage to createChannel hook dependency list

### DIFF
--- a/src/hooks/useCreateGroupChannel.ts
+++ b/src/hooks/useCreateGroupChannel.ts
@@ -71,7 +71,7 @@ export function useCreateGroupChannel(
     }
     // we dont want to watchout for change of whole objects
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUser?.userId, botUser?.userId]);
+  }, [currentUser?.userId, botUser?.userId, firstMessage]);
 
   useEffect(() => {
     // console.log('## useCreateGroupChannel: ', currentUser, botUser, sb);
@@ -82,7 +82,7 @@ export function useCreateGroupChannel(
       createAndSetNewChannel();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUser?.userId, botUser?.userId]);
+  }, [currentUser?.userId, botUser?.userId, firstMessage]);
 
   return [channel, createAndSetNewChannel, creating];
 }


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-304 

### What's the issue?
When the refresh icon is clicked, the [two functions below are executed](https://github.com/sendbird/chat-ai-widget/blob/develop/src/components/CustomChannelHeader.tsx#L74):  

```
  setFirstMessage(null);
  createGroupChannel(); 
```

The `createGroupChannel` custom hook uses the `firstMessage` inside the effect function. 
However, the `firstMessage` state has not been included in the effect's dependency array, causing the initialized state not to be reflected correctly. 

### How did I fix it? 
I simply added the missing `firstMessage` to the dependency array. 

