### PR TITLE
feat: set instantConnect option to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ const memoizedConfigureSession = useCallback(
   },[]);
 
 const customConfigs = {
+  // If instantConnect set to `true`, the SDK connection will be established right after mounting the Chat or ChatAiWidget component
+  instantConnect: true / false,
   configureSession: memoizedConfigureSession,
   customRefreshComponent: {
     icon: 'Your SVG icon',
@@ -268,6 +270,7 @@ const App = () => {
       userId={USER_ID}
       configureSession={customConfigs.configureSession}
       customRefreshComponent={customConfigs.customRefreshComponent}
+      instantConnect={customConfigs.instantConnect}
       {...customConstants}
     />
   );

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -44,8 +44,7 @@ type MessageMeta = {
 
 export function CustomChannelComponent(props: CustomChannelComponentProps) {
   const { botUser, createGroupChannel } = props;
-  const { userId, suggestedMessageContent, instantConnect } =
-    useConstantState();
+  const { userId, suggestedMessageContent } = useConstantState();
   const { allMessages, currentGroupChannel } = useChannelContext();
   const lastMessageRef = useRef<HTMLDivElement>(null);
 
@@ -109,10 +108,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
   }, [lastMessage?.messageId]);
 
   return (
-    <Root
-      hidePlaceholder={startingPagePlaceHolder}
-      height={instantConnect ? '100vh' : '100%'}
-    >
+    <Root hidePlaceholder={startingPagePlaceHolder} height={'100%'}>
       <ChannelUI
         renderChannelHeader={() => {
           return channel && createGroupChannel ? (

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -13,7 +13,7 @@ const spinner = keyframes`
 
 const Container = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/const.ts
+++ b/src/const.ts
@@ -61,8 +61,8 @@ export const DEFAULT_CONSTANT: Constant = {
       headerTwo: 'Ask me anything!',
     },
     messageContent: {
-      header: '',
-      body: '',
+      header: 'AI ChatBot',
+      body: "Hi~ I'm Khan Academy Support ChatBot. Ask me anything!",
     },
     logoContent: {
       Component: StartingPageLogo,
@@ -84,7 +84,7 @@ export const DEFAULT_CONSTANT: Constant = {
       'In this beta version, the AI-generated responses may lack complete accuracy.',
   },
   replacementTextList: [['the Text extracts', 'ChatBot Knowledge Base']],
-  instantConnect: false,
+  instantConnect: true,
   customRefreshComponent: {
     icon: RefreshIcon,
     width: '16px',

--- a/src/hooks/useCreateGroupChannel.ts
+++ b/src/hooks/useCreateGroupChannel.ts
@@ -34,7 +34,8 @@ export function useCreateGroupChannel(
   const store = useSendbirdStateContext();
   const sb: SendbirdGroupChat = store.stores.sdkStore.sdk as SendbirdGroupChat;
   const sendUserMessage = sendbirdSelectors.getSendUserMessage(store);
-  const { createGroupChannelParams } = useConstantState();
+  const { createGroupChannelParams, startingPageContent, instantConnect } =
+    useConstantState();
   const { setSbConnectionStatus, firstMessage } = useSbConnectionState();
 
   const createAndSetNewChannel = useCallback(async () => {
@@ -43,11 +44,20 @@ export function useCreateGroupChannel(
     }
     try {
       setCreating(true);
+      const firstMessageData =
+        instantConnect && startingPageContent?.messageContent?.body != null
+          ? JSON.stringify({
+              first_message_data: [
+                { data: [], message: startingPageContent.messageContent.body },
+              ],
+            })
+          : undefined;
       const params: GroupChannelCreateParams = {
         name: createGroupChannelParams?.name,
         invitedUserIds: [currentUser.userId, botUser.userId],
         isDistinct: false,
         coverUrl: createGroupChannelParams?.coverUrl,
+        data: firstMessageData,
       };
       const groupChannel = await sb.groupChannel
         .createChannel(params)


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-311


#### What's the issue?
Due to delays in establishing connections after sending a first message (#6), the application's connection has been experiencing instability. 

#### How I resolved it?
So I set the `instantConnect` option to true by default, ensuring stable connections without unexpected behaviors.

https://github.com/sendbird/chat-ai-widget/assets/10060731/7892ca0a-9484-48b6-af25-a99005df466c


