### PR TITLE
fix: incorrect quick replies format

### DIFF
--- a/src/components/BotMessageWithBodyInput.tsx
+++ b/src/components/BotMessageWithBodyInput.tsx
@@ -66,9 +66,7 @@ export default function BotMessageWithBodyInput(props: Props) {
     props;
 
   return (
-    <Root
-      style={{ zIndex: messageCount === 1 && zIndex ? zIndex : 0 }}
-    >
+    <Root style={{ zIndex: messageCount === 1 && zIndex ? zIndex : 0 }}>
       <ImageContainer>
         <img
           src={botMessageImage}

--- a/src/hooks/useScrollOnStreaming.ts
+++ b/src/hooks/useScrollOnStreaming.ts
@@ -17,7 +17,7 @@ export function useScrollOnStreaming({
     if (bottomBuffer > 0) {
       element.style.scrollMarginBottom = `${bottomBuffer}px`;
     }
-  }, 30);
+  }, 0);
 
   useEffect(() => {
     const observer = new ResizeObserver((entries) => {


### PR DESCRIPTION
Fixed the incorrect `data.quick_replies` format (I thought it'd an array but it's an object) 

Additionally, I also fixed the scroll behavior too. When the answer message from the bot is only 1 line, the throttling makes the auto-scroll not work. So I tried to remove the delayed time as well. 
<img width="421" alt="Screenshot 2023-08-16 at 1 50 05 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/60c7abdb-8018-420b-bcbe-42f3b86667b8">
