### PR TITLE
feat: attatch quick reply UI to bottom of bot message

### DIFF
--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -14,7 +14,6 @@ import CustomChannelHeader from './CustomChannelHeader';
 import CustomMessage from './CustomMessage';
 import CustomMessageInput from './CustomMessageInput';
 import DynamicRepliesPanel from './DynamicRepliesPanel';
-import StaticRepliesPanel from './StaticRepliesPanel';
 import { useConstantState } from '../context/ConstantContext';
 import { useScrollOnStreaming } from '../hooks/useScrollOnStreaming';
 import { isSpecialMessage, scrollUtil } from '../utils';
@@ -43,7 +42,7 @@ type MessageMeta =
   | {
       stream: boolean;
     }
-  | { quick_replies?: string[] };
+  | Array<{ quick_replies?: string[] }>;
 
 export function CustomChannelComponent(props: CustomChannelComponentProps) {
   const { botUser, createGroupChannel } = props;
@@ -76,9 +75,10 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
 
   const dynamicReplyOptions =
     lastMessageMeta != null &&
-    'quick_replies' in lastMessageMeta &&
-    lastMessageMeta.quick_replies != null
-      ? lastMessageMeta.quick_replies
+    Array.isArray(lastMessageMeta) &&
+    lastMessageMeta.length > 0 &&
+    lastMessageMeta[0] != null
+      ? lastMessageMeta[0].quick_replies ?? []
       : [];
 
   const isStaticReplyVisible =
@@ -143,11 +143,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
                 backgroundColor: 'white',
               }}
             >
-              {dynamicReplyOptions.length > 0 ? (
-                <DynamicRepliesPanel replyOptions={dynamicReplyOptions} />
-              ) : (
-                isStaticReplyVisible && <StaticRepliesPanel botUser={botUser} />
-              )}
+              {/* {isStaticReplyVisible && <StaticRepliesPanel botUser={botUser} />} */}
               <CustomMessageInput />
               <ChatBottom />
             </div>
@@ -155,12 +151,17 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
         }}
         renderMessage={({ message }: { message: EveryMessage }) => {
           return (
-            <CustomMessage
-              message={message}
-              activeSpinnerId={activeSpinnerId}
-              botUser={botUser}
-              lastMessageRef={lastMessageRef}
-            />
+            <>
+              <CustomMessage
+                message={message}
+                activeSpinnerId={activeSpinnerId}
+                botUser={botUser}
+                lastMessageRef={lastMessageRef}
+              />
+              {dynamicReplyOptions.length > 0 && (
+                <DynamicRepliesPanel replyOptions={dynamicReplyOptions} />
+              )}
+            </>
           );
         }}
         renderTypingIndicator={() => <></>}

--- a/src/components/DynamicRepliesPanel.tsx
+++ b/src/components/DynamicRepliesPanel.tsx
@@ -45,8 +45,7 @@ const Panel = styled.div`
   flex-wrap: wrap;
   column-gap: 10px;
   row-gap: 8px;
-  margin-top: 4px;
-  margin-right: 16px;
+  margin-top: 16px;
   flex-direction: column;
 `;
 


### PR DESCRIPTION
Address https://sendbird.atlassian.net/browse/AC-356

**AS-IS**
<img width="350" alt="Screenshot 2023-08-24 at 6 12 23 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/8fb06827-b579-4a90-8dc6-7a6a0af3ed01">
The quick reply component was used to be at the top of the message input box but it makes the scroll behavior flaky. 

**TO-BE**
<img width="350" alt="Screenshot 2023-08-24 at 5 24 51 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/73523e0f-dc52-479c-860d-9b9c8f430895">
So I just moved the quick reply component to the bottom of bot message.