### PR TITLE
fix: incorrect quick reply format

### DIFF
--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -42,7 +42,7 @@ type MessageMeta =
   | {
       stream: boolean;
     }
-  | Array<{ quick_replies?: string[] }>;
+  | { quick_replies?: string[] };
 
 export function CustomChannelComponent(props: CustomChannelComponentProps) {
   const { botUser, createGroupChannel } = props;
@@ -75,10 +75,9 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
 
   const dynamicReplyOptions =
     lastMessageMeta != null &&
-    Array.isArray(lastMessageMeta) &&
-    lastMessageMeta.length > 0 &&
-    lastMessageMeta[0] != null
-      ? lastMessageMeta[0].quick_replies ?? []
+    'quick_replies' in lastMessageMeta &&
+    lastMessageMeta.quick_replies != null
+      ? lastMessageMeta.quick_replies
       : [];
 
   const isStaticReplyVisible =
@@ -150,6 +149,10 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
           );
         }}
         renderMessage={({ message }: { message: EveryMessage }) => {
+          const isLastBotMessage =
+            !(message?.messageType === 'admin') &&
+            (message as ClientUserMessage)?.sender.userId === botUser.userId &&
+            message.createdAt === lastMessage.createdAt;
           return (
             <>
               <CustomMessage
@@ -158,7 +161,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
                 botUser={botUser}
                 lastMessageRef={lastMessageRef}
               />
-              {dynamicReplyOptions.length > 0 && (
+              {isLastBotMessage && dynamicReplyOptions.length > 0 && (
                 <DynamicRepliesPanel replyOptions={dynamicReplyOptions} />
               )}
             </>

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -149,10 +149,6 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
           );
         }}
         renderMessage={({ message }: { message: EveryMessage }) => {
-          const isLastBotMessage =
-            !(message?.messageType === 'admin') &&
-            (message as ClientUserMessage)?.sender.userId === botUser.userId &&
-            message.createdAt === lastMessage.createdAt;
           return (
             <>
               <CustomMessage
@@ -161,9 +157,10 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
                 botUser={botUser}
                 lastMessageRef={lastMessageRef}
               />
-              {isLastBotMessage && dynamicReplyOptions.length > 0 && (
-                <DynamicRepliesPanel replyOptions={dynamicReplyOptions} />
-              )}
+              {message.messageId === lastMessage.messageId &&
+                dynamicReplyOptions.length > 0 && (
+                  <DynamicRepliesPanel replyOptions={dynamicReplyOptions} />
+                )}
             </>
           );
         }}

--- a/src/const.ts
+++ b/src/const.ts
@@ -51,14 +51,12 @@ export const DEFAULT_CONSTANT: Constant = {
   },
   firstMessageData: [
     {
-      data: [
-        {
-          quick_replies: [
-            'What can I learn from Pre-K 8th grade?',
-            'Tell me about Math',
-          ],
-        },
-      ],
+      data: {
+        quick_replies: [
+          'What can I learn from Pre-K 8th grade?',
+          'Tell me about Math',
+        ],
+      },
       message: "Hi~ I'm Khan Academy Support ChatBot. Ask me anything!",
     },
   ],
@@ -121,7 +119,7 @@ type MessageData = {
 };
 
 type FirstMessageItem = {
-  data: MessageData[];
+  data: MessageData;
   message: string;
 };
 

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -29,7 +29,7 @@ export const ConstantStateProvider = (props: ProviderProps) => {
         props.customBetaMarkText ?? initialState.customBetaMarkText,
       suggestedMessageContent:
         props.suggestedMessageContent ?? initialState.suggestedMessageContent,
-      firstMessageData: props.firstMessageData ?? initialState.firstMessageData,
+      firstMessageData: props.firstMessageData ?? [],
       createGroupChannelParams:
         props.createGroupChannelParams ?? initialState.createGroupChannelParams,
       startingPageContent:

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
+import { DEFAULT_CONSTANT } from './const';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <App 
+      firstMessageData={DEFAULT_CONSTANT.firstMessageData}
+    />
   </React.StrictMode>
 );


### PR DESCRIPTION
Fixes https://sendbird.atlassian.net/browse/AC-364

Should be consistent when user pass the firstMessageData by modifying the source code or changing the setting via Sendbird dashbord. 

- When the first message & quick reply data are set via dashboard
<img width="422" alt="Screenshot 2023-08-25 at 2 19 27 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/b99b1696-a0db-4ac5-b2af-213a27769c74">

- When the values are set via source code
<img width="423" alt="Screenshot 2023-08-25 at 2 22 17 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/32449b3d-eb59-4e45-8c8f-462a071d8f29">


Both cases should work as expected