### PR TITLE
feat: introduce ai widget script loading for non-react users 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ## What is this for?
-It is for the Sendbird Chat AI Widget UiKit.
+This is a Sendbird Chat AI Widget implemented on top of [React UiKit](https://github.com/sendbird/sendbird-uikit-react).
 
 ![output](https://github.com/sendbird/chat-ai-widget/assets/104121286/dc6f93e7-bfba-46e9-8b45-36ce4a9581d4)
-
 
 ## How to use
 0. Prepare Sendbird ***Application ID*** and ***Bot ID***
@@ -27,6 +26,8 @@ It is for the Sendbird Chat AI Widget UiKit.
      );
    }
    ```
+
+  > Not using React in your environment? You can also load this Chat AI Widget component from an HTML file on your website. Please refer to [js-example.html](./js-example.html) for an example.
 
 ## Run locally
 ```bash

--- a/js-example.html
+++ b/js-example.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Load React first and then, ReactDOM. Also, these two libs' version should be same -->
+    <script crossorigin src="https://unpkg.com/react@18.2.0/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.development.js"></script>
+
+    <!-- Load chat-ai-widget script and set process.env to prevent it get undefined -->
+    <script>process = { env: { NODE_ENV: '' } }</script>
+    <script
+      crossorigin
+      src="https://unpkg.com/@sendbird/chat-ai-widget@latest/dist/index.umd.js"
+    ></script>
+    <link href="https://unpkg.com/@sendbird/chat-ai-widget@latest/dist/style.css" rel="stylesheet" />
+    <!--Optional; to enable JSX syntax-->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+    <title>chat-ai-widget Example</title>
+  </head>
+  <body>
+  <!-- div element for chat-ai-widget container -->
+  <div id="root"></div>
+
+  <!-- Initialize chat-ai-widget and render the widget component -->
+  <script type="text/babel">
+    const { ChatAiWidget } = window.ChatAiWidget
+    const App = () => {
+      return (
+        <ChatAiWidget
+          applicationId="AE8F7EEA-4555-4F86-AD8B-5E0BD86BFE67"
+          botId="khan-academy-bot"
+        />
+      )
+    }
+    ReactDOM.createRoot(document.querySelector('#root')).render(<div><App/></div>);
+  </script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,9 +33,15 @@ export default defineConfig({
       external: [
         'react',
         'react-dom',
-        'styled-components',
         'react-code-blocks',
       ],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+          'react-code-blocks': 'ReactCodeBlocks',
+        }
+      }
     }
   },
 })


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-376 

### Why we're doing this?
We are making these changes to assist users who do not use React or any other JavaScript framework or library. Our aim is to enable them to utilize this widget library without any additional dependencies, simply by loading the script from their website (HTML file).

Here's a working example: 
<img width="1719" alt="Screenshot 2023-08-30 at 5 15 28 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/844cad49-7c66-4aea-8dbb-8fc14a865bf6">

Additionally, I have included `js-example.html` as a quick reference example.