### PR TITLE
fix: set scroll block option to 'end' from 'nearest'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## What is this for?
 This is a Sendbird Chat AI Widget implemented on top of [React UiKit](https://github.com/sendbird/sendbird-uikit-react).
 
-![output](https://github.com/sendbird/chat-ai-widget/assets/104121286/dc6f93e7-bfba-46e9-8b45-36ce4a9581d4)
+![chat-ai-widget](https://github.com/sendbird/chat-ai-widget/assets/104121286/360d2a17-dfc6-4810-a7c4-2f0615b43c3d)
 
 ## How to use
 0. Prepare Sendbird ***Application ID*** and ***Bot ID***

--- a/src/hooks/useScrollOnStreaming.ts
+++ b/src/hooks/useScrollOnStreaming.ts
@@ -13,7 +13,7 @@ export function useScrollOnStreaming({
   bottomBuffer,
 }: Params) {
   const throttledScrollIntoView = useThrottle((element: HTMLDivElement) => {
-    element.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    element.scrollIntoView({ block: 'end', behavior: 'smooth' });
     if (bottomBuffer > 0) {
       element.style.scrollMarginBottom = `${bottomBuffer}px`;
     }


### PR DESCRIPTION
Just realized that the scroll block option should be 'end' to make sure the scroll downs to the end on streaming. 
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#parameters