### PR TITLE
feat: Merge sender profile when message is sent in short span of time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/chat-ai-widget",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "dependencies": {
         "@sendbird/chat": "^4.9.8",
-        "@sendbird/uikit-react": "^3.6.7",
+        "@sendbird/uikit-react": "^3.6.8",
         "dompurify": "^3.0.4",
         "polished": "^2.3.1",
         "react-code-blocks": "^0.1.0",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@sendbird/chat": {
-      "version": "4.9.8",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.9.8.tgz",
-      "integrity": "sha512-tRTr/5iXl4Fhxon6T8yO2xaRxvyO2KctFjqdEHVLW9JuhWEAWiWZsY/5Lbxivi/Pt+ebiQuBhl/af3V1WOJDCg==",
+      "version": "4.9.10",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.9.10.tgz",
+      "integrity": "sha512-WR2DoFu190/8Z6UhSjeNNQE6vIhrfBgwH5hdL0Jb4mVQNm8bSBd9jbwlDzvBAZCAqHxvXwNU+rH2VlKvaw84wQ==",
       "peerDependencies": {
         "@react-native-async-storage/async-storage": "^1.17.6"
       },
@@ -1032,11 +1032,11 @@
       }
     },
     "node_modules/@sendbird/uikit-react": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/@sendbird/uikit-react/-/uikit-react-3.6.7.tgz",
-      "integrity": "sha512-zI0STEYg4W8UjsmOf6JO8YAgHTz1x/8IID2oGfa2jaJ2GkQG1oDsd93iudXg+Zt5Dqs7oOiByH+nOfLvJYvxOQ==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/@sendbird/uikit-react/-/uikit-react-3.6.8.tgz",
+      "integrity": "sha512-tdWbxh5DH/sqMnMBinKTcSh+Ke63CYq6WJAwStFTHstHpopu5+xb2TmNqmW5dh10JMrO7VawTi+6XVXvFJMOlA==",
       "dependencies": {
-        "@sendbird/chat": "^4.9.6",
+        "@sendbird/chat": "^4.9.9",
         "@sendbird/uikit-tools": "0.0.1-alpha.40",
         "css-vars-ponyfill": "^2.3.2",
         "date-fns": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@sendbird/chat": "^4.9.8",
-    "@sendbird/uikit-react": "^3.6.7",
+    "@sendbird/uikit-react": "^3.6.8",
     "dompurify": "^3.0.4",
     "polished": "^2.3.1",
     "react-code-blocks": "^0.1.0",

--- a/src/components/BotMessageWithBodyInput.tsx
+++ b/src/components/BotMessageWithBodyInput.tsx
@@ -54,6 +54,8 @@ type Props = {
   botUser: User;
   message: UserMessage;
   bodyComponent: ReactNode;
+  chainTop: boolean;
+  chainBottom: boolean;
   messageCount?: number;
   zIndex?: number;
   bodyStyle?: object;
@@ -61,29 +63,50 @@ type Props = {
 
 const ImageContainer = styled.div``;
 
-export default function BotMessageWithBodyInput(props: Props) {
-  const { botUser, message, bodyComponent, messageCount, zIndex, bodyStyle } =
-    props;
+const EmptyImageContainer = styled.div`
+  width: 30px;
+`;
 
+export default function BotMessageWithBodyInput(props: Props) {
+  const {
+    botUser,
+    message,
+    bodyComponent,
+    messageCount,
+    zIndex,
+    bodyStyle,
+    chainTop,
+    chainBottom,
+  } = props;
+
+  const nonChainedMessage = chainTop == null && chainBottom == null;
+  const displayProfileImage = nonChainedMessage || chainBottom;
+  const displaySender = nonChainedMessage || chainTop;
   return (
     <Root style={{ zIndex: messageCount === 1 && zIndex ? zIndex : 0 }}>
-      <ImageContainer>
-        <img
-          src={botMessageImage}
-          alt="botProfileImage"
-          style={{
-            height: '28px',
-          }}
-        />
-      </ImageContainer>
+      {displayProfileImage ? (
+        <ImageContainer>
+          <img
+            src={botMessageImage}
+            alt="botProfileImage"
+            style={{
+              height: '28px',
+            }}
+          />
+        </ImageContainer>
+      ) : (
+        <EmptyImageContainer />
+      )}
       <BodyContainer style={bodyStyle ?? {}}>
-        <Sender
-          style={{
-            textAlign: 'left',
-          }}
-        >
-          {botUser.nickname}
-        </Sender>
+        {displaySender && (
+          <Sender
+            style={{
+              textAlign: 'left',
+            }}
+          >
+            {botUser.nickname}
+          </Sender>
+        )}
         {bodyComponent}
       </BodyContainer>
       <SentTime>{formatCreatedAtToAMPM(message.createdAt)}</SentTime>

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -17,6 +17,7 @@ import DynamicRepliesPanel from './DynamicRepliesPanel';
 import { useConstantState } from '../context/ConstantContext';
 import { useScrollOnStreaming } from '../hooks/useScrollOnStreaming';
 import { isSpecialMessage, scrollUtil } from '../utils';
+import { groupMessagesByShortSpanTime } from '../utils/messages';
 
 const Root = styled.div<{ hidePlaceholder: boolean; height: string }>`
   height: ${({ height }) => height};
@@ -120,6 +121,11 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
     }
   }, [lastMessage?.messageId]);
 
+  const grouppedMessages = useMemo(
+    () => groupMessagesByShortSpanTime(allMessages),
+    [allMessages.length]
+  );
+
   return (
     <Root hidePlaceholder={startingPagePlaceHolder} height={'100%'}>
       <ChannelUI
@@ -149,6 +155,9 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
           );
         }}
         renderMessage={({ message }: { message: EveryMessage }) => {
+          const grouppedMessage = grouppedMessages.find(
+            (m) => m.messageId == message.messageId
+          );
           return (
             <>
               <CustomMessage
@@ -156,6 +165,8 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
                 activeSpinnerId={activeSpinnerId}
                 botUser={botUser}
                 lastMessageRef={lastMessageRef}
+                chainTop={grouppedMessage.chaintop}
+                chainBottom={grouppedMessage.chainBottom}
               />
               {message.messageId === lastMessage.messageId &&
                 dynamicReplyOptions.length > 0 && (

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -165,8 +165,8 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
                 activeSpinnerId={activeSpinnerId}
                 botUser={botUser}
                 lastMessageRef={lastMessageRef}
-                chainTop={grouppedMessage.chaintop}
-                chainBottom={grouppedMessage.chainBottom}
+                chainTop={grouppedMessage?.chaintop}
+                chainBottom={grouppedMessage?.chainBottom}
               />
               {message.messageId === lastMessage.messageId &&
                 dynamicReplyOptions.length > 0 && (

--- a/src/components/CustomMessage.tsx
+++ b/src/components/CustomMessage.tsx
@@ -26,10 +26,19 @@ type Props = {
   activeSpinnerId: number;
   botUser: User;
   lastMessageRef: React.RefObject<HTMLDivElement>;
+  chainTop?: boolean;
+  chainBottom?: boolean;
 };
 
 export default function CustomMessage(props: Props) {
-  const { message, activeSpinnerId, botUser, lastMessageRef } = props;
+  const {
+    message,
+    activeSpinnerId,
+    botUser,
+    lastMessageRef,
+    chainTop,
+    chainBottom,
+  } = props;
   const { replacementTextList } = useConstantState();
 
   const { allMessages } = useChannelContext();
@@ -63,6 +72,8 @@ export default function CustomMessage(props: Props) {
           messageCount={allMessages.length}
           zIndex={30}
           bodyStyle={{ maxWidth: '255px', width: 'calc(100% - 98px)' }}
+          chainTop={chainTop}
+          chainBottom={chainBottom}
         />
       </div>
     );
@@ -81,6 +92,8 @@ export default function CustomMessage(props: Props) {
           }
           bodyStyle={{ maxWidth: '320px', width: 'calc(100% - 98px)' }}
           messageCount={allMessages.length}
+          chainTop={chainTop}
+          chainBottom={chainBottom}
         />
       );
     }
@@ -110,6 +123,8 @@ export default function CustomMessage(props: Props) {
             tokens={tokens}
           />
         }
+        chainTop={chainTop}
+        chainBottom={chainBottom}
       />
     </div>
   );

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { LOCAL_MESSAGE_CUSTOM_TYPE } from './const';
+import { LOCAL_MESSAGE_CUSTOM_TYPE } from '../const';
 
 export function uuid() {
   let d = new Date().getTime();

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-unresolved
 import { EveryMessage } from 'SendbirdUIKitGlobal';
 
+const TIME_SPAN = 3 * 60 * 1000;
 /**
  * Function to group messages based on their creation time
  *
@@ -17,7 +18,7 @@ export function groupMessagesByShortSpanTime(
     const prevKey = Object.keys(groups)[Object.keys(groups).length - 1];
 
     // Check if the time difference between the current message and the previous one is within 3 minutes
-    if (prevKey && message.createdAt - Number(prevKey) <= 3 * 60 * 1000) {
+    if (prevKey && message.createdAt - Number(prevKey) <= TIME_SPAN) {
       // Add the message to the existing group
       return {
         ...groups,

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,0 +1,49 @@
+// eslint-disable-next-line import/no-unresolved
+import { EveryMessage } from 'SendbirdUIKitGlobal';
+
+/**
+ * Function to group messages based on their creation time
+ *
+ * @param {EveryMessage[]} messages - Array of messages to group
+ * @returns {EveryMessage[]} - Array of messages grouped by creation time
+ */
+export function groupMessagesByShortSpanTime(
+  messages: EveryMessage[]
+): EveryMessage[] {
+  // Create an object to group messages based on their creation time
+  const groupedMessagesByCreatedAt = messages.reduce((groups, message) => {
+    const { createdAt } = message;
+    // Get the key of the previous group
+    const prevKey = Object.keys(groups)[Object.keys(groups).length - 1];
+
+    // Check if the time difference between the current message and the previous one is within 3 minutes
+    if (prevKey && message.createdAt - Number(prevKey) <= 3 * 60 * 1000) {
+      // Add the message to the existing group
+      return {
+        ...groups,
+        [prevKey]: [...(groups[prevKey] ?? []), message],
+      };
+    } else {
+      // Create a new group for the current message
+      return {
+        ...groups,
+        [createdAt]: [message],
+      };
+    }
+  }, {});
+
+  // Flatten the grouped messages and add chain indicators
+  return Object.values(groupedMessagesByCreatedAt).flatMap(
+    (messages: EveryMessage[]) => {
+      if (messages.length > 1) {
+        // Add chain indicators to the first and last messages in the group
+        return messages.map((message, index) => ({
+          ...message,
+          chaintop: index === 0,
+          chainBottom: index === messages.length - 1,
+        }));
+      }
+      return messages;
+    }
+  );
+}


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-438

**AS-IS** 
Display the profile image & bot nickname for every single message 
<img width="300" alt="Screenshot 2023-09-06 at 6 01 45 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/a7eebdc0-fce2-4afc-892d-ce4430f946d0">

**TO-BE**
Display only the first message's bot nickname & last one's profile image within the certain span of time(3min in our case)
<img width="300" alt="Screenshot 2023-09-06 at 5 57 55 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/6e77e502-c9a8-4e4d-a783-45b20f7f26ef">

