### PR TITLE
fix: make profile img invisible only when consecutive msg senders are same

### DIFF
--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -13,7 +13,7 @@ export function groupMessagesByShortSpanTime(
 ): EveryMessage[] {
   // Create an object to group messages based on their creation time
   const groupedMessagesByCreatedAt = messages.reduce((groups, message, idx) => {
-    const { createdAt, sender } = message;
+    const { createdAt, sender, messageType } = message;
     // Get the key of the previous group
     const prevKey = Object.keys(groups)[Object.keys(groups).length - 1];
 
@@ -21,6 +21,7 @@ export function groupMessagesByShortSpanTime(
     if (
       prevKey &&
       createdAt - Number(prevKey) <= TIME_SPAN &&
+      messageType !== 'admin' &&
       sender?.userId === messages[idx - 1]?.sender.userId
     ) {
       // Add the message to the existing group

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -12,13 +12,17 @@ export function groupMessagesByShortSpanTime(
   messages: EveryMessage[]
 ): EveryMessage[] {
   // Create an object to group messages based on their creation time
-  const groupedMessagesByCreatedAt = messages.reduce((groups, message) => {
-    const { createdAt } = message;
+  const groupedMessagesByCreatedAt = messages.reduce((groups, message, idx) => {
+    const { createdAt, sender } = message;
     // Get the key of the previous group
     const prevKey = Object.keys(groups)[Object.keys(groups).length - 1];
 
     // Check if the time difference between the current message and the previous one is within 3 minutes
-    if (prevKey && message.createdAt - Number(prevKey) <= TIME_SPAN) {
+    if (
+      prevKey &&
+      createdAt - Number(prevKey) <= TIME_SPAN &&
+      sender?.userId === messages[idx - 1]?.sender.userId
+    ) {
       // Add the message to the existing group
       return {
         ...groups,


### PR DESCRIPTION


### What's the issue?
After #50 merged, the bot's profile image is invisible even though the consecutive messages' senders are different. 
<img width="600" alt="Screenshot 2023-09-11 at 1 13 58 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/5686b628-66f1-4b0d-874c-6d3535fe6310">

The 1st bot message's profile image & 2nd bot message's nickname in the screenshot are invisible which is not the expected behavior.

### With this patch 
The 1st bot message's profile image & 2nd bot message's nickname in the screenshot should be visible. 
<img width="600" alt="Screenshot 2023-09-11 at 1 14 29 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/2c628486-4f3a-488c-b531-40b68ff5c13f">