### PR TITLE
Add optional chaining to sender.userId

### DIFF
--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -60,7 +60,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
   ] as ClientUserMessage;
   const isLastBotMessage =
     !(lastMessage?.messageType === 'admin') &&
-    (lastMessage as ClientUserMessage)?.sender.userId === botUser.userId;
+    (lastMessage as ClientUserMessage)?.sender?.userId === botUser.userId;
 
   const [activeSpinnerId, setActiveSpinnerId] = useState(-1);
 
@@ -88,7 +88,7 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
     allMessages &&
     allMessages.length > 1 &&
     !(lastMessage?.messageType === 'admin') &&
-    lastMessage.sender.userId === botUser.userId &&
+    lastMessage.sender?.userId === botUser.userId &&
     // in streaming
     lastMessageMeta != null &&
     'stream' in lastMessageMeta &&

--- a/src/components/CustomMessage.tsx
+++ b/src/components/CustomMessage.tsx
@@ -53,7 +53,7 @@ export default function CustomMessage(props: Props) {
   }
 
   // Sent by current user
-  if ((message as UserMessage).sender.userId !== botUser.userId) {
+  if ((message as UserMessage).sender?.userId !== botUser.userId) {
     return (
       <div>
         {<CurrentUserMessage message={message as UserMessage} />}

--- a/src/components/StaticRepliesPanel.tsx
+++ b/src/components/StaticRepliesPanel.tsx
@@ -102,7 +102,7 @@ const StaticRepliesPanel = (props: Props) => {
   useEffect(() => {
     if (
       lastMessage &&
-      lastMessage.sender.userId === botUser.userId &&
+      lastMessage.sender?.userId === botUser.userId &&
       isNotLocalMessageCustomType(lastMessage.customType)
     ) {
       setSuggestedReplies(suggestedMessageContent.replyContents);

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -22,7 +22,7 @@ export function groupMessagesByShortSpanTime(
       prevKey &&
       createdAt - Number(prevKey) <= TIME_SPAN &&
       messageType !== 'admin' &&
-      sender?.userId === messages[idx - 1]?.sender.userId
+      sender?.userId === messages[idx - 1]?.sender?.userId
     ) {
       // Add the message to the existing group
       return {
@@ -60,17 +60,17 @@ export function getBotWelcomeMessages(
 ) {
   // if the list is empty or the first message is not from bot,
   // we just assume there's no welcome messages
-  if (messages.length === 0 || messages[0]?.sender.userId !== botUserId) {
+  if (messages.length === 0 || messages[0]?.sender?.userId !== botUserId) {
     return [];
   }
 
   // if the list has only bot messages, then just return the whole list
-  if (messages.every((message) => message?.sender.userId === botUserId)) {
+  if (messages.every((message) => message?.sender?.userId === botUserId)) {
     return messages;
   }
 
   const firstUserMesssage = messages.find(
-    (message) => message?.sender.userId !== botUserId
+    (message) => message?.sender?.userId !== botUserId
   );
   return messages.slice(0, messages.indexOf(firstUserMesssage));
 }


### PR DESCRIPTION
An admin msg doesn't have `sender` object in the message data. So I just put an optional chaining not to make it throw a runtime error. 