### PR TITLE
fix: welcome message URL parsing

### DIFF
--- a/src/components/CustomMessage.tsx
+++ b/src/components/CustomMessage.tsx
@@ -101,25 +101,6 @@ export default function CustomMessage(props: Props) {
     );
   }
 
-  if (message.messageId === firstMessageId) {
-    return (
-      <div>
-        <BotMessageWithBodyInput
-          botUser={botUser}
-          message={message}
-          bodyComponent={
-            <CustomMessageBody message={(message as UserMessage).message} />
-          }
-          messageCount={allMessages.length}
-          zIndex={30}
-          chainTop={chainTop}
-          chainBottom={chainBottom}
-          isBotWelcomeMessage={isBotWelcomeMessage}
-        />
-      </div>
-    );
-  }
-
   // Sent by bot
   // suggested message
   if (!isNotLocalMessageCustomType(message.customType)) {

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -17,7 +17,6 @@ const Container = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  position: absolute;
   z-index: 100;
   background-color: white;
 `;


### PR DESCRIPTION
Fixes https://sendbird.atlassian.net/browse/AC-753

Just removed unnecessary condition for the welcome message. It doesn't need to be handled separately than the other normal messages.
Confirmed that a URL link in the first message is being correctly parsed. 
<img width="755" alt="Screenshot 2023-11-09 at 3 31 33 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/1c634409-43c4-4fcd-a1e5-5d9803be0f99">
