### PR TITLE
fix: set overflow-y `hidden`

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -51,3 +51,7 @@
 .sendbird-conversation__messages-padding {
   padding: 0 16px !important;
 }
+
+.sendbird-message-input .sendbird-message-input-text-field {
+  overflow-y: hidden;
+}


### PR DESCRIPTION
Problem:  The CSS on the right side of the input message area is incorrect
<img width="392" alt="Screenshot 2023-11-25 at 10 42 50 AM" src="https://github.com/sendbird/chat-ai-widget/assets/104121286/f10443b9-5675-4fce-9482-876c4c5c3721">

Fix: overwrite the CSS of `.sendbird-message-input .sendbird-message-input-text-field` to `overflow-y: hidden;`