### PR TITLE
release: 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [v1.1.1] (Feb 2 2024)
+
+#### Feat:
+- Added missing profile URL image prop
+- Used bot profileUrl & nickname in the channel header
+- Applied text overflow attribute to message input element
+
+#### Chore:
+- Excluded Pull Request option from Github.io deployment configuration
+
 ## [v1.1.0] (Nov 9 2023)
 #### Feat:
 - Renamed `quick_replies` to `suggested_replies`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/chat-ai-widget",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",


### PR DESCRIPTION
## [v1.1.1] (Feb 2 2024)

#### Feat:
- Added missing profile URL image prop
- Used bot profileUrl & nickname in the channel header
- Applied text overflow attribute to message input element

#### Chore:
- Excluded Pull Request option from Github.io deployment configuration