### PR TITLE
release: 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v1.1.3] (Feb 13 2024)
+#### Fix:
+- Changed source display indexing from the last item to the first
+- Added a filtering option for the source list by `source_type`
+
 ## [v1.1.2] (Feb 7 2024)
 #### Fix:
 - Fixed text alignment issue with sendbird-message-input-text-field

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",


### PR DESCRIPTION
## [v1.1.3] (Feb 13 2024)
#### Fix:
- Changed source display indexing from the last item to the first
- Added a filtering option for the source list by `source_type`