### PR TITLE
release: 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [v1.2.0] (Feb 26 2024)
+#### Feat:
+- Introduced mobile view support: Users can now enable mobile view compatibility using the enableMobileView prop. To enable, simply set `enableMobileView={true}`. Default value is true.
+```
+  <ChatAiWidget
+    {...other props}
+    enableMobileView={true / false}
+  />
+```
+- Implemented Sendbird ChatAiWidget self-service integration: Detailed instructions for self-service integration can be found at here.
+  - [Shopify](https://sendbird.com//docs/ai-chatbot/guide/v1/widget-integration/shopify)
+  - [Wix](https://sendbird.com//docs/ai-chatbot/guide/v1/widget-integration/wix)
+  - [Wordpress](https://sendbird.com//docs/ai-chatbot/guide/v1/widget-integration/wordpress)
+- Removed `startingPage` related logic and props:
+  - These options, present since the early versions of the widget, have been deprecated due to extensive error pruning and lack of utilization in core functionalities. [Related PR Link](https://github.com/sendbird/chat-ai-widget/pull/92)
+
+
 ## [v1.1.3] (Feb 13 2024)
 #### Fix:
 - Changed source display indexing from the last item to the first

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/embed-example.html
+++ b/packages/self-service/embed-example.html
@@ -7,6 +7,8 @@
     <title>Vite + React + TS</title>
     <link rel="preload" href="https://fonts.cdnfonts.com/css/gellix" rel="stylesheet">
     <link rel="preload" href="https://fonts.cdnfonts.com/css/sf-pro-display" rel="stylesheet">
+  </head>
+  <body>
     <script>
       !function(w, d, s, ...args){
         var div = d.createElement('div');
@@ -17,11 +19,9 @@
         j = d.createElement(s);
         j.defer = true;
         j.type = 'module';
-        j.src = 'https://aichatbot.sendbird.com/index.js/index.js';
+        j.src = 'https://aichatbot.sendbird.com/index.js';
         f.parentNode.insertBefore(j, f);
       }(window, document, 'script', 'A3E33A85-E4A7-46A4-99B1-EF6833E7DE3A', 'marketing_bot_3');
     </script>
-  </head>
-  <body>
   </body>
 </html>

--- a/packages/self-service/package-lock.json
+++ b/packages/self-service/package-lock.json
@@ -8,7 +8,7 @@
       "name": "self-service",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "1.1.3-self-service-rc-8",
+        "@sendbird/chat-ai-widget": "^1.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.1.3-self-service-rc-8",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.1.3-self-service-rc-8.tgz",
-      "integrity": "sha512-4s+U4GdKyE7Ds2EK6WRLl05Xu3dFSpKBpHpC+DFBfuiC2m77GbDthESZQ1U+e4lcJqIoScfs6pKyxAirfHncnA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.0.tgz",
+      "integrity": "sha512-zDLKTC7MP88siAT3mpxfvSgUX/Zj4zlk3UovbOaDa7tsJEIUdGcTLGaeCpdaVF8fA6IZnanDrRonll6iyGs0lg==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",
@@ -7097,9 +7097,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.1.3-self-service-rc-8",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.1.3-self-service-rc-8.tgz",
-      "integrity": "sha512-4s+U4GdKyE7Ds2EK6WRLl05Xu3dFSpKBpHpC+DFBfuiC2m77GbDthESZQ1U+e4lcJqIoScfs6pKyxAirfHncnA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.0.tgz",
+      "integrity": "sha512-zDLKTC7MP88siAT3mpxfvSgUX/Zj4zlk3UovbOaDa7tsJEIUdGcTLGaeCpdaVF8fA6IZnanDrRonll6iyGs0lg==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -14,7 +14,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "1.1.3-self-service-rc-8",
+    "@sendbird/chat-ai-widget": "^1.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/url-webdemo/package-lock.json
+++ b/packages/url-webdemo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "url-webdemo",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "1.1.3-self-service-rc-8",
+        "@sendbird/chat-ai-widget": "^1.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -983,9 +983,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.1.3-self-service-rc-8",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.1.3-self-service-rc-8.tgz",
-      "integrity": "sha512-4s+U4GdKyE7Ds2EK6WRLl05Xu3dFSpKBpHpC+DFBfuiC2m77GbDthESZQ1U+e4lcJqIoScfs6pKyxAirfHncnA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.0.tgz",
+      "integrity": "sha512-zDLKTC7MP88siAT3mpxfvSgUX/Zj4zlk3UovbOaDa7tsJEIUdGcTLGaeCpdaVF8fA6IZnanDrRonll6iyGs0lg==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",
@@ -4303,9 +4303,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.1.3-self-service-rc-8",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.1.3-self-service-rc-8.tgz",
-      "integrity": "sha512-4s+U4GdKyE7Ds2EK6WRLl05Xu3dFSpKBpHpC+DFBfuiC2m77GbDthESZQ1U+e4lcJqIoScfs6pKyxAirfHncnA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.0.tgz",
+      "integrity": "sha512-zDLKTC7MP88siAT3mpxfvSgUX/Zj4zlk3UovbOaDa7tsJEIUdGcTLGaeCpdaVF8fA6IZnanDrRonll6iyGs0lg==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",

--- a/packages/url-webdemo/package.json
+++ b/packages/url-webdemo/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@sendbird/chat-ai-widget": "1.1.3-self-service-rc-8"
+    "@sendbird/chat-ai-widget": "^1.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",


### PR DESCRIPTION
## [v1.2.0] (Feb 26 2024)
#### Feat:
- Introduced mobile view support: Users can now enable mobile view compatibility using the enableMobileView prop. To enable, simply set `enableMobileView={true}`. Default value is true.
```
  <ChatAiWidget
    {...other props}
    enableMobileView={true / false}
  />
```
- Implemented Sendbird ChatAiWidget self-service integration: Detailed instructions for self-service integration can be found at [here](https://sendbird.com/docs/ai-chatbot/guide/v1/widget-integration).
- Removed `startingPage` related logic and props:
  - These options, present since the early versions of the widget, have been deprecated due to extensive error pruning and lack of utilization in core functionalities. [Related PR Link](https://github.com/sendbird/chat-ai-widget/pull/92)
