### PR TITLE
fix: mix isLoading & isPending \w isFetching in query hook

### DIFF
--- a/src/hooks/useChannelStyle.ts
+++ b/src/hooks/useChannelStyle.ts
@@ -24,7 +24,7 @@ export const useChannelStyle = ({
   appId: string;
   botId: string;
 }) => {
-  const { data, isFetching } = useQuery({
+  const { data, isPending, isLoading, isFetching } = useQuery({
     enabled: !!appId && !!botId,
     queryKey: ['getChannelStyle', appId, botId],
     retry: 0,
@@ -60,8 +60,9 @@ export const useChannelStyle = ({
       }
     },
   });
+  const fetching = isPending || isLoading || isFetching;
   return useMemo(() => {
-    if (data == null) return { ...DEFAULT_CHANNEL_STYLE, isFetching };
-    return { ...data, isFetching };
-  }, [data != null, isFetching]);
+    if (data == null) return { ...DEFAULT_CHANNEL_STYLE, isFetching: fetching };
+    return { ...data, isFetching: fetching };
+  }, [data != null, fetching]);
 };


### PR DESCRIPTION
Aims to fix 

https://github.com/sendbird/chat-ai-widget/assets/10060731/0c792ccf-3c07-41f4-89e0-843b5934a927

And how I investigated and got the solution. 
https://sendbird.slack.com/archives/C0585965FFA/p1709009403618109?thread_ts=1709001029.081029&cid=C0585965FFA