### PR TITLE
Apply multiple feedback from customer 

### DIFF
--- a/src/components/BotMessageWithBodyInput.tsx
+++ b/src/components/BotMessageWithBodyInput.tsx
@@ -13,6 +13,7 @@ import { SentTime, BodyContainer } from './MessageComponent';
 import { ReactionContainer } from './ReactionContainer';
 import { useConstantState } from '../context/ConstantContext';
 import { formatCreatedAtToAMPM } from '../utils';
+import { isLastMessageInStreaming } from '../utils/messages';
 
 const Root = styled.span`
   display: flex;
@@ -37,11 +38,12 @@ type Props = {
   botUser: User;
   message: UserMessage;
   bodyComponent: ReactNode;
-  chainTop: boolean;
-  chainBottom: boolean;
+  chainTop?: boolean;
+  chainBottom?: boolean;
   messageCount?: number;
   zIndex?: number;
   isBotWelcomeMessage?: boolean;
+  isLastBotMessage?: boolean;
   isFormMessage?: boolean;
 };
 
@@ -62,6 +64,7 @@ export default function BotMessageWithBodyInput(props: Props) {
     chainTop,
     chainBottom,
     isBotWelcomeMessage,
+    isLastBotMessage,
     isFormMessage = false,
   } = props;
 
@@ -107,6 +110,7 @@ export default function BotMessageWithBodyInput(props: Props) {
             {enableEmojiFeedback &&
               displayProfileImage &&
               !isBotWelcomeMessage &&
+              !(isLastBotMessage && isLastMessageInStreaming(message)) &&
               !isFormMessage && <ReactionContainer message={message} />}
           </>
           <SentTime>{formatCreatedAtToAMPM(message.createdAt)}</SentTime>

--- a/src/components/CurrentUserMessage.tsx
+++ b/src/components/CurrentUserMessage.tsx
@@ -2,15 +2,18 @@ import { UserMessage } from '@sendbird/chat/message';
 import styled from 'styled-components';
 
 import { SentTime, BodyContainer, BodyComponent } from './MessageComponent';
+import { useConstantState } from '../context/ConstantContext';
 import { formatCreatedAtToAMPM } from '../utils';
 
-const Root = styled.div`
+const Root = styled.div<{ enableEmojiFeedback: boolean }>`
   display: flex;
   justify-content: flex-end;
   align-items: end;
   margin-bottom: 6px;
   flex-wrap: wrap-reverse;
   gap: 8px;
+  margin-top: ${({ enableEmojiFeedback }) =>
+    enableEmojiFeedback ? '20px' : '0'};
 `;
 
 const TextComponent = styled.div`
@@ -22,10 +25,11 @@ type Props = {
 };
 
 export default function CurrentUserMessage(props: Props) {
+  const { enableEmojiFeedback } = useConstantState();
   const { message } = props;
 
   return (
-    <Root>
+    <Root enableEmojiFeedback={enableEmojiFeedback}>
       <SentTime>
         <div>{formatCreatedAtToAMPM(message.createdAt)}</div>
       </SentTime>

--- a/src/components/CustomMessage.tsx
+++ b/src/components/CustomMessage.tsx
@@ -29,6 +29,7 @@ type Props = {
   botUser: User;
   lastMessageRef: React.RefObject<HTMLDivElement>;
   isBotWelcomeMessage: boolean;
+  isLastBotMessage: boolean;
   messageCount: number;
   chainTop?: boolean;
   chainBottom?: boolean;
@@ -43,8 +44,17 @@ export default function CustomMessage(props: Props) {
     chainTop,
     chainBottom,
     isBotWelcomeMessage,
+    isLastBotMessage,
     messageCount,
   } = props;
+  const commonProps = {
+    chainTop,
+    chainBottom,
+    isBotWelcomeMessage,
+    isLastBotMessage,
+    messageCount,
+    message,
+  };
   const { replacementTextList, userId } = useConstantState();
 
   // admin message
@@ -56,13 +66,9 @@ export default function CustomMessage(props: Props) {
     const forms = message.extendedMessagePayload.forms;
     return (
       <BotMessageWithBodyInput
+        {...commonProps}
         botUser={botUser}
-        message={message}
         bodyComponent={<FormMessage form={forms[0]} message={message} />}
-        messageCount={messageCount}
-        chainTop={chainTop}
-        chainBottom={chainBottom}
-        isBotWelcomeMessage={isBotWelcomeMessage}
         isFormMessage={true}
       />
     );
@@ -86,10 +92,8 @@ export default function CustomMessage(props: Props) {
       <div ref={lastMessageRef}>
         {
           <UserMessageWithBodyInput
-            message={message as UserMessage}
+            {...commonProps}
             user={message?.sender}
-            chainTop={chainTop}
-            chainBottom={chainBottom}
             bodyComponent={
               <CustomMessageBody message={(message as UserMessage).message} />
             }
@@ -105,15 +109,11 @@ export default function CustomMessage(props: Props) {
     if (message.customType === LOCAL_MESSAGE_CUSTOM_TYPE.linkSuggestion) {
       return (
         <BotMessageWithBodyInput
+          {...commonProps}
           botUser={botUser}
-          message={message}
           bodyComponent={
             <SuggestedReplyMessageBody message={message as UserMessage} />
           }
-          messageCount={messageCount}
-          chainTop={chainTop}
-          chainBottom={chainBottom}
-          isBotWelcomeMessage={isBotWelcomeMessage}
         />
       );
     }
@@ -134,18 +134,14 @@ export default function CustomMessage(props: Props) {
   return (
     <div ref={lastMessageRef}>
       <BotMessageWithBodyInput
+        {...commonProps}
         botUser={botUser}
-        message={message}
-        messageCount={messageCount}
         bodyComponent={
           <ParsedBotMessageBody
             message={message as UserMessage}
             tokens={tokens}
           />
         }
-        chainTop={chainTop}
-        chainBottom={chainBottom}
-        isBotWelcomeMessage={isBotWelcomeMessage}
       />
     </div>
   );

--- a/src/components/ParsedBotMessageBody.tsx
+++ b/src/components/ParsedBotMessageBody.tsx
@@ -13,12 +13,11 @@ const LazyCodeBlock = lazy(() =>
 );
 
 const Text = styled.div`
-  width: fit-content;
+  width: inherit;
   text-align: left;
   word-break: break-word;
   padding: 8px 12px;
   gap: 12px;
-  border-radius: 16px;
   white-space: pre-wrap;
   background-color: ${({ theme }) => theme.bgColor.incomingMessage};
   &:hover {
@@ -28,6 +27,11 @@ const Text = styled.div`
 
 const BlockContainer = styled.div`
   width: 100%;
+`;
+
+const MultipleTokenTypeContainer = styled.div`
+  border-radius: 16px;
+  overflow: auto;
 `;
 
 type Props = {
@@ -57,7 +61,7 @@ export default function ParsedBotMessageBody(props: Props) {
   // console.log('## sources: ', sources);
   if (tokens.length > 0) {
     return (
-      <>
+      <MultipleTokenTypeContainer>
         {tokens.map((token: Token, i) => {
           if (token.type === TokenType.string) {
             return (
@@ -81,8 +85,8 @@ export default function ParsedBotMessageBody(props: Props) {
             <BotMessageBottom />
           </>
         ) : null}
-      </>
+      </MultipleTokenTypeContainer>
     );
   }
-  return <Text>{message.message}</Text>;
+  return <Text style={{ borderRadius: 16 }}>{message.message}</Text>;
 }

--- a/src/components/UserMessageWithBodyInput.tsx
+++ b/src/components/UserMessageWithBodyInput.tsx
@@ -44,8 +44,8 @@ type Props = {
   user: User;
   message: UserMessage;
   bodyComponent: ReactNode;
-  chainTop: boolean;
-  chainBottom: boolean;
+  chainTop?: boolean;
+  chainBottom?: boolean;
   isBotWelcomeMessage?: boolean;
   isFormMessage?: boolean;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,25 +16,14 @@ export const scrollUtil = () => {
     const scrollDOM = document.querySelector(
       '.sendbird-conversation__messages-padding'
     );
-    //console.warn(scrollDOM);
     if (scrollDOM) {
       const { scrollHeight, clientHeight } = scrollDOM;
-      // const isScrolledToEnd = (scrollTop + 200) > (scrollHeight - clientHeight);
       const isScrolledToEnd = true;
-
-      // console.warn({
-      //   scrollTop,
-      //   scrollHeight,
-      //   clientHeight,
-      //   [scrollHeight - clientHeight]: scrollHeight - clientHeight,
-      //   isScrolledToEnd,
-      // });
       if (isScrolledToEnd) {
-        //console.warn('move to end', scrollDOM.scrollHeight + 200)
         scrollDOM.scrollTop = scrollHeight - clientHeight + 200;
       }
     }
-  }); // We may need ~500ms delay here.
+  });
 };
 
 export function formatCreatedAtToAMPM(createdAt: number) {
@@ -186,9 +175,9 @@ export function replaceTextExtracts(
 
 export function replaceUrl(input: string): string {
   const urlRegex =
-    /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/gi;
+    /(?:https?:\/\/|www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.(xn--)?[a-z]{2,20}\b([-a-zA-Z0-9@:%_+[\],.~#?&/=]*[-a-zA-Z0-9@:%_+~#?&/=])*/g;
   return input.replace(urlRegex, function (url) {
-    return `<a href="${url}" target="_blank">${url}</a>`;
+    return `<a class="sendbird-word__url" href="${url}" target="_blank">${url}</a>`;
   });
 }
 

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -78,3 +78,15 @@ export function getBotWelcomeMessages(
 export function isFormMessage(message: EveryMessage) {
   return !!message.extendedMessagePayload?.forms;
 }
+
+export function isLastMessageInStreaming(lastMessage: EveryMessage | null) {
+  if (
+    lastMessage == null ||
+    lastMessage?.data == null ||
+    lastMessage?.data === ''
+  ) {
+    return false;
+  }
+  const messageMetaData = JSON.parse(lastMessage.data);
+  return 'stream' in messageMetaData && messageMetaData.stream;
+}


### PR DESCRIPTION
Applies https://sendbird.atlassian.net/browse/AC-1500

 - [x] 👍 👎 emojis should not be displayed when streaming message is being sent 
 - [x] URL text message(from bot) should be parsed as a link format 
 - [x] Code snippet should be displayed correctly (has been broken since self service PR)

#### Before
![Screenshot 2024-02-27 at 3 27 43 PM](https://github.com/sendbird/chat-ai-widget/assets/10060731/296d5a3f-1ba6-40ac-b7ff-b91879309e72)

#### After
- code snippet
<img width="400" alt="Screenshot 2024-02-27 at 5 25 01 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/509612d2-c6aa-4c6c-9f21-bb6f6d5a7f1b">

- URL link
<img width="565" alt="Screenshot 2024-02-27 at 5 25 12 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/3f22b809-150c-4ce3-ae54-67d75ee2bbe3">

- Display the feedback emoji after streaming is done
https://github.com/sendbird/chat-ai-widget/assets/10060731/ce901ba5-cfed-4749-b371-7e4e84159d55

