### PR TITLE
release: v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [v1.2.1] (Feb 27 2024)
+#### Feat:
+- Improved user experience based on customer feedback:
+  - Excluded display of 👍👎 emojis during message streaming.
+  - Modified URL text messages from bots to be parsed as links.
+  - Fixed display of code snippets which had been broken since the self-service https://github.com/sendbird/chat-ai-widget/pull/87.
+
+#### Fix:
+- Replaced Channel module with GroupChannel to address issues.
+- Used `isLoading` and `isPending` along with `isFetching` in `useChannelStyle` query hook to get the loading status.
+
+
 ## [v1.2.0] (Feb 26 2024)
 #### Feat:
 - Introduced mobile view support: Users can now enable mobile view compatibility using the enableMobileView prop. To enable, simply set `enableMobileView={true}`. Default value is true.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Excluded display of 👍👎 emojis during message streaming.
   - Modified URL text messages from bots to be parsed as links.
   - Fixed display of code snippets which had been broken since the self-service https://github.com/sendbird/chat-ai-widget/pull/87.
+- Added `renderWidgetToggleButton` prop to support custom widget toggle button rendering.
 
 #### Fix:
 - Replaced Channel module with GroupChannel to address issues.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package-lock.json
+++ b/packages/self-service/package-lock.json
@@ -8,7 +8,7 @@
       "name": "self-service",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.2.0",
+        "@sendbird/chat-ai-widget": "^1.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.0.tgz",
-      "integrity": "sha512-zDLKTC7MP88siAT3mpxfvSgUX/Zj4zlk3UovbOaDa7tsJEIUdGcTLGaeCpdaVF8fA6IZnanDrRonll6iyGs0lg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.1.tgz",
+      "integrity": "sha512-HVTQ4tqaATOXbbgB1D28NFZQ5ACP+g1GVAYxKO6KP15b3D01rmZ5ZItygaxzKyrLhIlseBsbskWz7VrH7jF45A==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",
@@ -7097,9 +7097,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.0.tgz",
-      "integrity": "sha512-zDLKTC7MP88siAT3mpxfvSgUX/Zj4zlk3UovbOaDa7tsJEIUdGcTLGaeCpdaVF8fA6IZnanDrRonll6iyGs0lg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.1.tgz",
+      "integrity": "sha512-HVTQ4tqaATOXbbgB1D28NFZQ5ACP+g1GVAYxKO6KP15b3D01rmZ5ZItygaxzKyrLhIlseBsbskWz7VrH7jF45A==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -14,7 +14,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "^1.2.0",
+    "@sendbird/chat-ai-widget": "^1.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/url-webdemo/package-lock.json
+++ b/packages/url-webdemo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "url-webdemo",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.2.0",
+        "@sendbird/chat-ai-widget": "^1.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -983,9 +983,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.0.tgz",
-      "integrity": "sha512-zDLKTC7MP88siAT3mpxfvSgUX/Zj4zlk3UovbOaDa7tsJEIUdGcTLGaeCpdaVF8fA6IZnanDrRonll6iyGs0lg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.1.tgz",
+      "integrity": "sha512-HVTQ4tqaATOXbbgB1D28NFZQ5ACP+g1GVAYxKO6KP15b3D01rmZ5ZItygaxzKyrLhIlseBsbskWz7VrH7jF45A==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",
@@ -4303,9 +4303,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.0.tgz",
-      "integrity": "sha512-zDLKTC7MP88siAT3mpxfvSgUX/Zj4zlk3UovbOaDa7tsJEIUdGcTLGaeCpdaVF8fA6IZnanDrRonll6iyGs0lg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.1.tgz",
+      "integrity": "sha512-HVTQ4tqaATOXbbgB1D28NFZQ5ACP+g1GVAYxKO6KP15b3D01rmZ5ZItygaxzKyrLhIlseBsbskWz7VrH7jF45A==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",

--- a/packages/url-webdemo/package.json
+++ b/packages/url-webdemo/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@sendbird/chat-ai-widget": "^1.2.0"
+    "@sendbird/chat-ai-widget": "^1.2.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",


### PR DESCRIPTION
## [v1.2.1] (Feb 27 2024)
#### Feat:
- Improved user experience based on customer feedback:
  - Excluded display of 👍👎 emojis during message streaming.
  - Modified URL text messages from bots to be parsed as links.
  - Fixed display of code snippets which had been broken since the self-service https://github.com/sendbird/chat-ai-widget/pull/87.
- Added `renderWidgetToggleButton` prop to support custom widget toggle button rendering.


#### Fix:
- Replaced Channel module with GroupChannel to address issues.
- Used `isLoading` and `isPending` along with `isFetching` in `useChannelStyle` query hook to get the loading status.
