### PR TITLE
release: v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [v1.2.3] (Mar 4 2024)
 #### Chore:
-- Injected `chat-ai-widget-key` key-value pair into the user agent parameter during build time.
+- Internal change
 
 ## [v1.2.2] (Mar 4 2024)
 #### Feat:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v1.2.3] (Mar 4 2024)
+#### Chore:
+- Injected `chat-ai-widget-key` key-value pair into the user agent parameter during build time.
+
 ## [v1.2.2] (Mar 4 2024)
 #### Feat:
 - Reduced initial loading time:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> NOTE: Please note that proper utilization through code build is available starting from the "AI Chatbot Pro" plan or higher of [the Sendbird AI Chatbot pricing plan](https://sendbird.com/pricing).
+
+
 ## What is this for?
 This is a Sendbird Chat AI Widget implemented on top of [React UiKit](https://github.com/sendbird/sendbird-uikit-react).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package-lock.json
+++ b/packages/self-service/package-lock.json
@@ -8,7 +8,7 @@
       "name": "self-service",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.2.2",
+        "@sendbird/chat-ai-widget": "^1.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.2.tgz",
-      "integrity": "sha512-Bvm/rkjDNqoQnISU65d2bpODKb2PKqQs/iHrwmousUsPjtu/Ui3GwmsjJapWRjylcDo9HI/TK/u5SHi70kOunw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.3.tgz",
+      "integrity": "sha512-9kCmvbDmRwVHx8EiOAURep/AN7DHIyEqskhc39OkfGckEe6dmHmnJWVEiBBCaU0pXx6sGkJ+P5EQbN8QLd3lTQ==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",
@@ -7097,9 +7097,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.2.tgz",
-      "integrity": "sha512-Bvm/rkjDNqoQnISU65d2bpODKb2PKqQs/iHrwmousUsPjtu/Ui3GwmsjJapWRjylcDo9HI/TK/u5SHi70kOunw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.3.tgz",
+      "integrity": "sha512-9kCmvbDmRwVHx8EiOAURep/AN7DHIyEqskhc39OkfGckEe6dmHmnJWVEiBBCaU0pXx6sGkJ+P5EQbN8QLd3lTQ==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -14,7 +14,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "^1.2.2",
+    "@sendbird/chat-ai-widget": "^1.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/url-webdemo/package-lock.json
+++ b/packages/url-webdemo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "url-webdemo",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.2.2",
+        "@sendbird/chat-ai-widget": "^1.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -983,9 +983,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.2.tgz",
-      "integrity": "sha512-Bvm/rkjDNqoQnISU65d2bpODKb2PKqQs/iHrwmousUsPjtu/Ui3GwmsjJapWRjylcDo9HI/TK/u5SHi70kOunw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.3.tgz",
+      "integrity": "sha512-9kCmvbDmRwVHx8EiOAURep/AN7DHIyEqskhc39OkfGckEe6dmHmnJWVEiBBCaU0pXx6sGkJ+P5EQbN8QLd3lTQ==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",
@@ -4303,9 +4303,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.2.tgz",
-      "integrity": "sha512-Bvm/rkjDNqoQnISU65d2bpODKb2PKqQs/iHrwmousUsPjtu/Ui3GwmsjJapWRjylcDo9HI/TK/u5SHi70kOunw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.2.3.tgz",
+      "integrity": "sha512-9kCmvbDmRwVHx8EiOAURep/AN7DHIyEqskhc39OkfGckEe6dmHmnJWVEiBBCaU0pXx6sGkJ+P5EQbN8QLd3lTQ==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.12.0",

--- a/packages/url-webdemo/package.json
+++ b/packages/url-webdemo/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@sendbird/chat-ai-widget": "^1.2.2"
+    "@sendbird/chat-ai-widget": "^1.2.3"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",


### PR DESCRIPTION
## [v1.2.3] (Mar 4 2024)
#### Chore:
- Injected `chat-ai-widget-key` key-value pair into the user agent parameter during build time.