### PR TITLE
chore: add self-service script publish guide

### DIFF
--- a/packages/self-service/embed-example.html
+++ b/packages/self-service/embed-example.html
@@ -19,9 +19,9 @@
         j = d.createElement(s);
         j.defer = true;
         j.type = 'module';
-        j.src = 'https://aichatbot.sendbird.com/index.js';
+        j.src = './dist/index.js';
         f.parentNode.insertBefore(j, f);
-      }(window, document, 'script', 'A3E33A85-E4A7-46A4-99B1-EF6833E7DE3A', 'marketing_bot_3');
+      }(window, document, 'script', 'YOUR_APP_ID', 'YOUR_BOT_ID');
     </script>
   </body>
 </html>

--- a/packages/self-service/embed-example.html
+++ b/packages/self-service/embed-example.html
@@ -21,7 +21,7 @@
         j.type = 'module';
         j.src = './dist/index.js';
         f.parentNode.insertBefore(j, f);
-      }(window, document, 'script', 'YOUR_APP_ID', 'YOUR_BOT_ID');
+      }(window, document, 'script', 'AE8F7EEA-4555-4F86-AD8B-5E0BD86BFE67', 'khan-academy-bot');
     </script>
   </body>
 </html>

--- a/packages/self-service/script-publish.md
+++ b/packages/self-service/script-publish.md
@@ -12,7 +12,7 @@ No specific prerequisites are required.
 
 ## Common Steps
 
-1. Test the functionality locally by building this directory with `npm run build`. Utilize [embed-example.html](./embed-example.html) for testing purposes. Remember to replace `YOUR_APP_ID` and `YOUR_BOT_ID` with the actual values.
+1. Test the functionality locally by building this directory with `npm run build`. Utilize [embed-example.html](./embed-example.html) for testing purposes.
 2. Create a new tag and push it to this repository. Monitor the package build status on the [Circle CI dashboard](https://app.circleci.com/pipelines/github/sendbird/chat-ai-widget).
 3. If the Circle CI dashboard displays a green light, proceed to [gate-k8s](https://github.com/sendbird/gate-k8s) and update the `common.version` value in [this file](https://github.com/sendbird/gate-k8s/blob/main/values/aichatbot/prod.yaml) with the tag created in step 2. [This PR](https://github.com/sendbird/gate-k8s/pull/1396) might be helpful to see how you can create a PR in the gate-k8s repository.
 4. Once your PR is merged to the main branch in gate-k8s, the new script will be deployed right away.

--- a/packages/self-service/script-publish.md
+++ b/packages/self-service/script-publish.md
@@ -1,0 +1,18 @@
+# Guide for Publishing Self-Service Script
+
+## Prerequisites
+
+### Case 1: When there are changes in `@sendbird/chat-ai-widget`:
+
+After successfully releasing the `chat-ai-widget` package, following the instructions in [release-guide.md](../../release-guide.md), update the version of `@sendbird/chat-ai-widget` to the latest in `package.json` using `npm install`. Ensure that `package-lock.json` is also updated.
+
+### Case 2: When there are changes only in `packages/self-service/*`:
+
+No specific prerequisites are required.
+
+## Common Steps
+
+1. Test the functionality locally by building this directory with `npm run build`. Utilize [embed-example.html](./embed-example.html) for testing purposes. Remember to replace `YOUR_APP_ID` and `YOUR_BOT_ID` with the actual values.
+2. Create a new tag and push it to this repository. Monitor the package build status on the [Circle CI dashboard](https://app.circleci.com/pipelines/github/sendbird/chat-ai-widget).
+3. If the Circle CI dashboard displays a green light, proceed to [gate-k8s](https://github.com/sendbird/gate-k8s) and update the `common.version` value in [this file](https://github.com/sendbird/gate-k8s/blob/main/values/aichatbot/prod.yaml) with the tag created in step 2. [This PR](https://github.com/sendbird/gate-k8s/pull/1396) might be helpful to see how you can create a PR in the gate-k8s repository.
+4. Once your PR is merged to the main branch in gate-k8s, the new script will be deployed right away.


### PR DESCRIPTION
Added a self-service script deployment guide just for quick reference. More detailed instructions will be added to Jira Confluence in the near future! 