### PR TITLE
release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [v1.3.2] (Mar 12 2024)
+#### Feat:
+- Added support for simple markdown formats in bot messages
+  - Supports bold format (`**bold**`)
+  - Supports link format (`[text](url)`)
+
+#### Fix:
+- Addressed issues related to rendering bot messages
+
 ## [v1.3.1] (Mar 8 2024)
 #### Fix:
 - Hide unused button icons

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/chat-ai-widget",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package-lock.json
+++ b/packages/self-service/package-lock.json
@@ -8,7 +8,7 @@
       "name": "self-service",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.3.1",
+        "@sendbird/chat-ai-widget": "^1.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.1.tgz",
-      "integrity": "sha512-f5ib6Pj/QziQdr0SxatLY7Bxitecoc9OKDqb03VxB/LxKwAzv9bRcBJoH54dduRVhuEPGI1eYtGwr1E50KR7Sw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.2.tgz",
+      "integrity": "sha512-8DaZdZb2+5Xw9D+SY8IIrvPnOidf66aNX29/NYOLLQ33w8wczt9UuAAHT0bRWpSbxG6HdHSyRM+sek6eIyfgVQ==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.13.1",
@@ -7119,9 +7119,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.1.tgz",
-      "integrity": "sha512-f5ib6Pj/QziQdr0SxatLY7Bxitecoc9OKDqb03VxB/LxKwAzv9bRcBJoH54dduRVhuEPGI1eYtGwr1E50KR7Sw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.2.tgz",
+      "integrity": "sha512-8DaZdZb2+5Xw9D+SY8IIrvPnOidf66aNX29/NYOLLQ33w8wczt9UuAAHT0bRWpSbxG6HdHSyRM+sek6eIyfgVQ==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.13.1",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -14,7 +14,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "^1.3.1",
+    "@sendbird/chat-ai-widget": "^1.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/url-webdemo/package-lock.json
+++ b/packages/url-webdemo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "url-webdemo",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.3.1",
+        "@sendbird/chat-ai-widget": "^1.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -983,9 +983,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.1.tgz",
-      "integrity": "sha512-f5ib6Pj/QziQdr0SxatLY7Bxitecoc9OKDqb03VxB/LxKwAzv9bRcBJoH54dduRVhuEPGI1eYtGwr1E50KR7Sw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.2.tgz",
+      "integrity": "sha512-8DaZdZb2+5Xw9D+SY8IIrvPnOidf66aNX29/NYOLLQ33w8wczt9UuAAHT0bRWpSbxG6HdHSyRM+sek6eIyfgVQ==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.13.1",
@@ -4325,9 +4325,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.1.tgz",
-      "integrity": "sha512-f5ib6Pj/QziQdr0SxatLY7Bxitecoc9OKDqb03VxB/LxKwAzv9bRcBJoH54dduRVhuEPGI1eYtGwr1E50KR7Sw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.2.tgz",
+      "integrity": "sha512-8DaZdZb2+5Xw9D+SY8IIrvPnOidf66aNX29/NYOLLQ33w8wczt9UuAAHT0bRWpSbxG6HdHSyRM+sek6eIyfgVQ==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.13.1",

--- a/packages/url-webdemo/package.json
+++ b/packages/url-webdemo/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@sendbird/chat-ai-widget": "^1.3.1"
+    "@sendbird/chat-ai-widget": "^1.3.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",


### PR DESCRIPTION
## [v1.3.2] (Mar 12 2024)
#### Feat:
- Added support for simple markdown formats in bot messages
  - Supports bold format (`**bold**`)
  - Supports link format (`[text](url)`)

#### Fix:
- Addressed issues related to rendering bot messages
