### PR TITLE
chore: apply dynamic import for index script caching

### DIFF
--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build:post": "node scripts/generate-index.js && cp dist/index.js dist/output.js",
+    "build:post": "node scripts/generate-index.js",
     "build": "rm -rf dist && tsc-silent -p './tsconfig.json' --suppress @ && vite build && npm run build:post",
     "preview": "vite preview",
     "lint": "npx eslint src",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "rm -rf dist && tsc-silent -p './tsconfig.json' --suppress @ && vite build",
+    "build:post": "node scripts/generate-index.js && cp dist/index.js dist/output.js",
+    "build": "rm -rf dist && tsc-silent -p './tsconfig.json' --suppress @ && vite build && npm run build:post",
     "preview": "vite preview",
     "lint": "npx eslint src",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/self-service/scripts/generate-index.js
+++ b/packages/self-service/scripts/generate-index.js
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+
+const packageLock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
+const version = packageLock.dependencies["@sendbird/chat-ai-widget"].version;
+
+if (!version) {
+    console.error('Error: No version found for @sendbird/chat-ai-widget. Please check the package-lock.json file.');
+    process.exit(1);
+}
+
+const content = `import(\`/output.js?v=${version}\`).then(() => console.log("AI chatbot module has been successfully loaded"));`;
+
+// For development
+fs.writeFileSync('dist/index-dev.js', content);
+
+// For production: Uncomment the following line after testing is done
+// fs.writeFileSync('dist/index.js', content);

--- a/packages/self-service/scripts/generate-index.js
+++ b/packages/self-service/scripts/generate-index.js
@@ -13,5 +13,5 @@ const content = `import(\`/output.js?v=${version}\`).then(() => console.log("AI 
 // For development
 fs.writeFileSync('dist/index-dev.js', content);
 
-// For production: Uncomment the following line after testing is done
-// fs.writeFileSync('dist/index.js', content);
+// For production
+fs.writeFileSync('dist/index.js', content);

--- a/packages/self-service/vite.config.ts
+++ b/packages/self-service/vite.config.ts
@@ -10,9 +10,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: undefined,
-        // Uncomment the following line once testing is done
-        // entryFileNames: `output.js`,
-        entryFileNames: `[name].js`,
+        entryFileNames: `output.js`,
         chunkFileNames: `[name].js`,
         assetFileNames: `[name].[ext]`,
         globals: {

--- a/packages/self-service/vite.config.ts
+++ b/packages/self-service/vite.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: undefined,
+        // Uncomment the following line once testing is done
+        // entryFileNames: `output.js`,
         entryFileNames: `[name].js`,
         chunkFileNames: `[name].js`,
         assetFileNames: `[name].[ext]`,


### PR DESCRIPTION
This is another trial to achieve the same goal as described in #118 but way simpler. Detailed discussion has been done in [here](https://sendbird.slack.com/archives/C05QD5M7XDH/p1710346722818999?thread_ts=1710324989.837639&cid=C05QD5M7XDH).

Below is the first step to test the whole process. Once I create a tag based on this branch, we'll be able to test this by loading aichatbot.sendbird.com/index-dev.js.

```mermaid
graph TD;
    B[npm run build] 
    B --> C{Is Build Successful?}
    C -->|Yes| D[Run 'generate-index.js']
    C -->|No| E[Stop Build Process]
    D --> F[Extract the current @sendbird/chat-ai-widget version from package-lock.json]
    F --> G[Create 'dist/index-dev.js' for testing purpose]
    B --> H[Create 'dist/index.js']
    H --> I[Copy 'dist/index.js' to 'dist/output.js' which will be dynamically loaded in index-dev.js & index.js]
    G --> J[End Build Process]
    I --> J
```

Once testing is done, the above process will be changed like (please refer to the comments that I left in the code)
```mermaid
graph TD;
    B[npm run build] 
    B --> C{Is Build Successful?}
    C -->|Yes| D[Run 'generate-index.js']
    C -->|No| E[Stop Build Process]
    D --> F[Extract the current @sendbird/chat-ai-widget version from package-lock.json]
    F --> G[Create 'dist/index-dev.js' for development env & `dist/index.js` for production]
    B --> H[Create 'dist/output.js' which will be dynamically loaded in index-dev.js & index.js]
    G --> J[End Build Process]
    H --> J
```