### PR TITLE
[AC-1747] Enable passing ChatAiWidget props to self service widget embed code

### DIFF
--- a/packages/self-service/src/App.tsx
+++ b/packages/self-service/src/App.tsx
@@ -6,12 +6,16 @@ import { uuid } from './utils';
 
 type ChatbotConfig = Window &
   typeof globalThis & {
-    chatbotConfig: string[]
+    chatbotConfig: string[];
   };
+// Available props are defined in the ChatAiWidget component
+type ChatbotProps = Record<never, never>;
 
 const USER_ID = uuid();
-const APP_ID = (window as ChatbotConfig).chatbotConfig?.[0]
-const BOT_ID = (window as ChatbotConfig).chatbotConfig?.[1]
+const APP_ID = (window as ChatbotConfig).chatbotConfig?.[0];
+const BOT_ID = (window as ChatbotConfig).chatbotConfig?.[1];
+const chatbotConfigs =
+  ((window as ChatbotConfig).chatbotConfig?.[2] as ChatbotProps) ?? {};
 
 function App() {
   return (
@@ -26,6 +30,7 @@ function App() {
       customUserAgentParam={{
         'chat-ai-widget-deployed': 'True',
       }}
+      {...chatbotConfigs}
     />
   );
 }

--- a/packages/self-service/src/App.tsx
+++ b/packages/self-service/src/App.tsx
@@ -1,6 +1,11 @@
 import '@sendbird/chat-ai-widget/dist/style.css';
 import './index.css';
-import { ChatAiWidget } from '@sendbird/chat-ai-widget';
+import {
+  ChatAiWidget,
+  // Remove below line once 1.3.5 released
+  // eslint-disable-next-line import/named
+  ChatAiWidgetConfigs,
+} from '@sendbird/chat-ai-widget';
 
 import { uuid } from './utils';
 
@@ -8,14 +13,14 @@ type ChatbotConfig = Window &
   typeof globalThis & {
     chatbotConfig: string[];
   };
-// Available props are defined in the ChatAiWidget component
-type ChatbotProps = Record<never, never>;
 
 const USER_ID = uuid();
 const APP_ID = (window as ChatbotConfig).chatbotConfig?.[0];
 const BOT_ID = (window as ChatbotConfig).chatbotConfig?.[1];
 const chatbotConfigs =
-  ((window as ChatbotConfig).chatbotConfig?.[2] as ChatbotProps) ?? {};
+  // Available configs are defined in the ChatAiWidget component
+  ((window as ChatbotConfig)
+    .chatbotConfig?.[2] as unknown as ChatAiWidgetConfigs) ?? {};
 
 function App() {
   return (

--- a/src/components/ParsedBotMessageBody.tsx
+++ b/src/components/ParsedBotMessageBody.tsx
@@ -3,10 +3,10 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import BotMessageBottom from './BotMessageBottom';
+import { CodeBlock } from './CodeBlock';
 import SourceContainer, { Source } from './SourceContainer';
 import { useConstantState } from '../context/ConstantContext';
 import { replaceWithRegex, Token, TokenType } from '../utils';
-import { CodeBlock } from './CodeBlock';
 
 const Text = styled.div`
   width: inherit;
@@ -55,7 +55,7 @@ export default function ParsedBotMessageBody(props: Props) {
   // console.log('## sources: ', sources);
   if (tokens.length > 0) {
     return (
-      <MultipleTokenTypeContainer>
+      <MultipleTokenTypeContainer className="sendbird-word">
         {tokens.map((token: Token, i) => {
           if (token.type === TokenType.string) {
             return (
@@ -128,7 +128,11 @@ export default function ParsedBotMessageBody(props: Props) {
       </MultipleTokenTypeContainer>
     );
   }
-  return <Text style={{ borderRadius: 16 }}>{message.message}</Text>;
+  return (
+    <Text className="sendbird-word" style={{ borderRadius: 16 }}>
+      {message.message}
+    </Text>
+  );
 }
 
 const urlRegex =

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
-export { default as ChatAiWidget } from './components/ChatAiWidget';
+export {
+  default as ChatAiWidget,
+  type Props as ChatAiWidgetConfigs,
+} from './components/ChatAiWidget';
 export { default as Chat } from './components/Chat';


### PR DESCRIPTION
There's a request from a user who's using self-service about possibility of widget customization. However, there's no way to achieve this since the embed code we provide from the dashboard is only inject appid / botid to the ChatAiWidget component and other config props are not being passed. 
So I added a connection between self-service <-> ChatAiWidget component like [this](https://github.com/sendbird/chat-ai-widget/pull/126/files#diff-8909f40095486fdc54c1782c9213f49e02cfbe73b2a7fe9295f91adef11d97c1R17).

This is a common guide we provide from Dashboard when user creates a bot.
```
<script>
      !function(w, d, s, ...args){
        var div = d.createElement('div');
        div.id = 'aichatbot';
        d.body.appendChild(div);
        w.chatbotConfig = args;
        var f = d.getElementsByTagName(s)[0],
        j = d.createElement(s);
        j.defer = true;
        j.type = 'module';
        j.src = 'https://aichatbot.sendbird.com/index.js';
        f.parentNode.insertBefore(j, f);
      }(window, document, 'script', 'AE8F7EEA-4555-4F86-AD8B-5E0BD86BFE67', 'khan-academy-bot');
</script>
```

If user wants to customize the embed code to pass the chatbot config props(to ChatAiWidget component), they can modify the above common embed code like below
```
<script>
      ... Same as above
        // This is what user needs to add; arg[0] is for appid & arg[1] is for botid 
        args[2] = {
          enableEmojiFeedback: true / false, 
          enableSourceMessage: true / false, 
          ... any other props defined in ChatAiWidget component can be listed here 
        }
      }(window, document, 'script', 'AE8F7EEA-4555-4F86-AD8B-5E0BD86BFE67', 'khan-academy-bot');
</script>
```