### PR TITLE
release: 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [1.3.5] (Mar 21 2024)
+## [1.3.5] (Mar 22 2024)
 #### Chore:
 - Inject className; `sendbird-word` to the message bubble component to make it customizable
+
+#### Feat:
+- Enable passing `stringSet` prop from ChatAiWiget to UIKit
+  - Available `stringSet` can be found at https://github.com/sendbird/sendbird-uikit-react/blob/main/src/ui/Label/stringSet.ts.
 
 ## [1.3.4] (Mar 19 2024)
 ### Feat:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.3.5] (Mar 21 2024)
+#### Chore:
+- Inject className; `sendbird-word` to the message bubble component to make it customizable
+
 ## [1.3.4] (Mar 19 2024)
 ### Feat:
 - Drop `react-code-block` library & add new CodeBlock component.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package-lock.json
+++ b/packages/self-service/package-lock.json
@@ -8,7 +8,7 @@
       "name": "self-service",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.3.4",
+        "@sendbird/chat-ai-widget": "^1.3.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -984,9 +984,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.4.tgz",
-      "integrity": "sha512-hD0+3Q6E0Mll6I8Hn7YvcvbBR9ngQAfQI2d/58d7cDcfqDZDgHiSsZwSBR0lxx3i3yK87wvRO3RS/6zV3aukag==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.5.tgz",
+      "integrity": "sha512-OKlAYPI62YvabdF9AP0TZHHSjZEwuhpX37pI/sYBHPc2ZqfCZqw6wC7i+on2QtZ77cjVa2fdUrB4SPIvSmjytg==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.13.1",
@@ -4013,9 +4013,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.4.tgz",
-      "integrity": "sha512-hD0+3Q6E0Mll6I8Hn7YvcvbBR9ngQAfQI2d/58d7cDcfqDZDgHiSsZwSBR0lxx3i3yK87wvRO3RS/6zV3aukag==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.5.tgz",
+      "integrity": "sha512-OKlAYPI62YvabdF9AP0TZHHSjZEwuhpX37pI/sYBHPc2ZqfCZqw6wC7i+on2QtZ77cjVa2fdUrB4SPIvSmjytg==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.13.1",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -15,7 +15,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "^1.3.4",
+    "@sendbird/chat-ai-widget": "^1.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/self-service/src/App.tsx
+++ b/packages/self-service/src/App.tsx
@@ -2,8 +2,6 @@ import '@sendbird/chat-ai-widget/dist/style.css';
 import './index.css';
 import {
   ChatAiWidget,
-  // Remove below line once 1.3.5 released
-  // eslint-disable-next-line import/named
   ChatAiWidgetConfigs,
 } from '@sendbird/chat-ai-widget';
 

--- a/packages/url-webdemo/package-lock.json
+++ b/packages/url-webdemo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "url-webdemo",
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.3.4",
+        "@sendbird/chat-ai-widget": "^1.3.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -983,9 +983,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.4.tgz",
-      "integrity": "sha512-hD0+3Q6E0Mll6I8Hn7YvcvbBR9ngQAfQI2d/58d7cDcfqDZDgHiSsZwSBR0lxx3i3yK87wvRO3RS/6zV3aukag==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.5.tgz",
+      "integrity": "sha512-OKlAYPI62YvabdF9AP0TZHHSjZEwuhpX37pI/sYBHPc2ZqfCZqw6wC7i+on2QtZ77cjVa2fdUrB4SPIvSmjytg==",
       "dependencies": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.13.1",
@@ -4003,9 +4003,9 @@
       "requires": {}
     },
     "@sendbird/chat-ai-widget": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.4.tgz",
-      "integrity": "sha512-hD0+3Q6E0Mll6I8Hn7YvcvbBR9ngQAfQI2d/58d7cDcfqDZDgHiSsZwSBR0lxx3i3yK87wvRO3RS/6zV3aukag==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.3.5.tgz",
+      "integrity": "sha512-OKlAYPI62YvabdF9AP0TZHHSjZEwuhpX37pI/sYBHPc2ZqfCZqw6wC7i+on2QtZ77cjVa2fdUrB4SPIvSmjytg==",
       "requires": {
         "@sendbird/chat": "^4.10.1",
         "@sendbird/uikit-react": "^3.13.1",

--- a/packages/url-webdemo/package.json
+++ b/packages/url-webdemo/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@sendbird/chat-ai-widget": "^1.3.4"
+    "@sendbird/chat-ai-widget": "^1.3.5"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",


### PR DESCRIPTION
## [1.3.5] (Mar 22 2024)
#### Chore:
- Inject className; `sendbird-word` to the message bubble component to make it customizable

#### Feat:
- Enable passing `stringSet` prop from ChatAiWiget to UIKit
  - Available `stringSet` can be found at https://github.com/sendbird/sendbird-uikit-react/blob/main/src/ui/Label/stringSet.ts.
