### PR TITLE
feat: enable stringSet customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,11 @@ const customConfigs = {
   // but setting this option to `true` will keep it open at all times.
   autoOpen: true / false,
   configureSession: memoizedConfigureSession,
+  // Available stringSet can be found at https://github.com/sendbird/sendbird-uikit-react/blob/main/src/ui/Label/stringSet.ts
+  stringSet: {{
+    MESSAGE_INPUT__PLACE_HOLDER: 'Type a message',
+    // ...
+  }}
   customRefreshComponent: {
     icon: 'Your SVG icon',
     style: {
@@ -311,6 +316,7 @@ const App = () => {
     <ChatAiWidget
       userId={USER_ID}
       configureSession={customConfigs.configureSession}
+      stringSet={customConfigs.stringSet}
       customRefreshComponent={customConfigs.customRefreshComponent}
       instantConnect={customConfigs.instantConnect}
       autoOpen={customConfigs.autoOpen}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ const App = (props: Props) => {
       instantConnect={props.instantConnect}
       customRefreshComponent={props.customRefreshComponent}
       configureSession={props.configureSession}
+      stringSet={props.stringSet}
       enableSourceMessage={props.enableSourceMessage}
       enableEmojiFeedback={props.enableEmojiFeedback}
       enableMention={props.enableMention}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -28,6 +28,7 @@ const SBComponent = () => {
     configureSession,
     enableMention,
     customUserAgentParam,
+    stringSet,
   } = useConstantState();
 
   assert(
@@ -80,6 +81,7 @@ const SBComponent = () => {
       isMentionEnabled={enableMention}
       theme={theme}
       colorSet={customColorSet}
+      stringSet={stringSet}
       uikitOptions={{
         groupChannel: {
           input: {

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,7 @@
 import SendbirdChat, { SessionHandler } from '@sendbird/chat';
 import { type SendbirdGroupChat } from '@sendbird/chat/groupChannel';
 import { type SendbirdOpenChat } from '@sendbird/chat/openChannel';
+import { type StringSet } from '@sendbird/uikit-react/types/ui/Label/stringSet';
 import React from 'react';
 
 import { ReactComponent as RefreshIcon } from './icons/refresh-icon.svg';
@@ -96,6 +97,7 @@ export interface Constant {
   enableMention: boolean;
   enableMobileView: boolean;
   firstMessageData: FirstMessageItem[];
+  stringSet: Partial<StringSet> | undefined;
 }
 
 export interface SuggestedReply {

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -67,6 +67,7 @@ export const ConstantStateProvider = (props: ProviderProps) => {
       },
       customUserAgentParam: props.customUserAgentParam,
       configureSession: props.configureSession,
+      stringSet: props.stringSet,
       enableSourceMessage:
         props.enableSourceMessage ?? initialState.enableSourceMessage,
       enableEmojiFeedback:


### PR DESCRIPTION
e.g.
![Screenshot 2024-03-22 at 11 51 24 AM](https://github.com/sendbird/chat-ai-widget/assets/10060731/b0082516-3533-47e8-8d39-1d1528cdc4b3)

^ This kind of string customization will be possible by passing `stringSet` prop to ChatAiWidget. It'll be passed to UIKit too. 