### PR TITLE
[AC-1769] feat: dismiss mobile keyboard after sending a message

### DIFF
--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -15,6 +15,7 @@ import CustomMessage from './CustomMessage';
 import DynamicRepliesPanel from './DynamicRepliesPanel';
 import StaticRepliesPanel from './StaticRepliesPanel';
 import { useConstantState } from '../context/ConstantContext';
+import useAutoDismissMobileKyeboardHandler from '../hooks/useAutoDismissMobileKyeboardHandler';
 import { useScrollOnStreaming } from '../hooks/useScrollOnStreaming';
 import { hideChatBottomBanner, isIOSMobile } from '../utils';
 import {
@@ -126,6 +127,9 @@ export function CustomChannelComponent(props: CustomChannelComponentProps) {
     scrollToBottom,
   } = useGroupChannelContext();
   const lastMessageRef = useRef<HTMLDivElement>(null);
+
+  useAutoDismissMobileKyeboardHandler();
+
   const lastMessage = allMessages?.[allMessages?.length - 1] as
     | SendableMessage
     | undefined;

--- a/src/hooks/useAutoDismissMobileKyeboardHandler.ts
+++ b/src/hooks/useAutoDismissMobileKyeboardHandler.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import { isIOSMobile } from '../utils';
 
@@ -6,8 +6,6 @@ const INPUT_ELEMENT_SELECTOR = '.sendbird-message-input';
 const SEND_BUTTON_SELECTOR = '.sendbird-message-input--send';
 
 function useAutoDismissMobileKeyboardHandler(): void {
-  const observerRef = useRef<MutationObserver | null>(null);
-
   useEffect(() => {
     const handleDismissKeyboard = (): void => {
       setTimeout(() => {
@@ -41,14 +39,14 @@ function useAutoDismissMobileKeyboardHandler(): void {
       }
     };
 
-    observerRef.current = new MutationObserver(observerCallback);
+    const observerRef = new MutationObserver(observerCallback);
     const config = { childList: true, subtree: true };
 
     const inputElement = document.querySelector<HTMLInputElement>(
       INPUT_ELEMENT_SELECTOR
     );
     if (inputElement) {
-      observerRef.current.observe(inputElement, config);
+      observerRef.observe(inputElement, config);
       inputElement.addEventListener('keydown', (event: KeyboardEvent) => {
         if (
           event.key === 'Enter' &&
@@ -63,7 +61,7 @@ function useAutoDismissMobileKeyboardHandler(): void {
     }
 
     return () => {
-      observerRef.current?.disconnect();
+      observerRef.disconnect();
       if (inputElement) {
         // Clean up event listener when the component is unmounted
         inputElement.removeEventListener('keydown', handleDismissKeyboard);

--- a/src/hooks/useAutoDismissMobileKyeboardHandler.ts
+++ b/src/hooks/useAutoDismissMobileKyeboardHandler.ts
@@ -19,7 +19,13 @@ function useAutoDismissMobileKeyboardHandler(): void {
     };
 
     const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === 'Enter' && isIOSMobile) {
+      if (
+        event.key === 'Enter' &&
+        // TODO: Pressing Enter key on Android keyboard does't trigger the sending message event
+        // but carriage return event is fired instead which is a different behavior from UIKit React.
+        // Need to find a way to handle this case.
+        isIOSMobile
+      ) {
         handleDismissKeyboard();
       }
     };

--- a/src/hooks/useAutoDismissMobileKyeboardHandler.ts
+++ b/src/hooks/useAutoDismissMobileKyeboardHandler.ts
@@ -32,6 +32,10 @@ function useAutoDismissMobileKeyboardHandler(): void {
               node.nodeType === Node.ELEMENT_NODE &&
               (node as Element).matches(SEND_BUTTON_SELECTOR)
             ) {
+              (node as HTMLElement).removeEventListener(
+                'click',
+                handleDismissKeyboard
+              );
               (node as HTMLElement).addEventListener(
                 'click',
                 handleDismissKeyboard
@@ -52,6 +56,7 @@ function useAutoDismissMobileKeyboardHandler(): void {
     );
     if (inputElement) {
       observerRef.observe(inputElement, config);
+      inputElement.removeEventListener('keydown', handleKeyDown);
       inputElement.addEventListener('keydown', handleKeyDown);
     } else {
       console.warn('Input element not found for mutation observer');

--- a/src/hooks/useAutoDismissMobileKyeboardHandler.ts
+++ b/src/hooks/useAutoDismissMobileKyeboardHandler.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+
+import { isIOSMobile } from '../utils';
+
+const INPUT_ELEMENT_SELECTOR = '.sendbird-message-input';
+const SEND_BUTTON_SELECTOR = '.sendbird-message-input--send';
+
+function useAutoDismissMobileKeyboardHandler(): void {
+  const observerRef = useRef<MutationObserver | null>(null);
+
+  useEffect(() => {
+    const handleDismissKeyboard = (): void => {
+      setTimeout(() => {
+        const inputElement = document.querySelector(INPUT_ELEMENT_SELECTOR);
+        if (
+          document.activeElement instanceof HTMLElement &&
+          inputElement instanceof HTMLElement
+        ) {
+          document.activeElement.blur(); // blur the active element to dismiss the keyboard on mobile
+          inputElement.blur(); // ensure the input element is also blurred
+        }
+      }, 200);
+    };
+
+    const observerCallback = (mutations: MutationRecord[]): void => {
+      for (const mutation of mutations) {
+        if (mutation.type === 'childList') {
+          const addedNodes = Array.from(mutation.addedNodes) as HTMLElement[];
+          // Why we're searching the button in this way?
+          // Because the send button is not rendered in the DOM tree until the user starts typing
+          const sendButton = addedNodes.find(
+            (node) =>
+              node.nodeType === Node.ELEMENT_NODE &&
+              node.matches(SEND_BUTTON_SELECTOR)
+          );
+
+          if (sendButton instanceof HTMLElement) {
+            sendButton.addEventListener('click', handleDismissKeyboard);
+          }
+        }
+      }
+    };
+
+    observerRef.current = new MutationObserver(observerCallback);
+    const config = { childList: true, subtree: true };
+
+    const inputElement = document.querySelector<HTMLInputElement>(
+      INPUT_ELEMENT_SELECTOR
+    );
+    if (inputElement) {
+      observerRef.current.observe(inputElement, config);
+      inputElement.addEventListener('keydown', (event: KeyboardEvent) => {
+        if (
+          event.key === 'Enter' &&
+          // Pressing Enter key on Android keyboard does't trigger the sending message event but carriage return event is fired instead
+          isIOSMobile
+        ) {
+          handleDismissKeyboard();
+        }
+      });
+    } else {
+      console.warn('Input element not found for mutation observer');
+    }
+
+    return () => {
+      observerRef.current?.disconnect();
+      if (inputElement) {
+        // Clean up event listener when the component is unmounted
+        inputElement.removeEventListener('keydown', handleDismissKeyboard);
+      }
+    };
+  }, []);
+}
+
+export default useAutoDismissMobileKeyboardHandler;


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-1769

### AS-IS
https://github.com/sendbird/chat-ai-widget/assets/10060731/ca7e2bc8-0cec-4f9f-9939-20b0f75661bf
-> The latest sent message is invisible because the mobile keyboard takes up most of the screen area.


### Expected scenario
1. Start typing in an input element 
2. The paper plane icon appears next to the input
3. Once the send button is clicked (or pressing Enter key on iOS), the mobile keyboard should be dismissed so the latest sent message is visible. 

#### Android
<img width="300px" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/e9508442-76e8-4be8-9c8b-4a984d245c4d" alt="android" />

#### iOS
<img width="300px" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/ccfe1106-ecb9-4148-a376-f134d41cde7d" alt="ios" />
