### PR TITLE
[AC-1747] Apply UIKit classNames to user message text & suggested replies

### DIFF
--- a/src/components/CurrentUserMessage.tsx
+++ b/src/components/CurrentUserMessage.tsx
@@ -16,10 +16,6 @@ const Root = styled.div<{ enableEmojiFeedback: boolean }>`
     enableEmojiFeedback ? '20px' : '0'};
 `;
 
-const TextComponent = styled.div`
-  white-space: pre-line;
-`;
-
 type Props = {
   message: UserMessage;
 };
@@ -35,7 +31,7 @@ export default function CurrentUserMessage(props: Props) {
       </SentTime>
       <BodyContainer>
         <BodyComponent>
-          <TextComponent>{message.message}</TextComponent>
+          <div className="sendbird-word">{message.message}</div>
         </BodyComponent>
       </BodyContainer>
     </Root>

--- a/src/components/CustomMessageBody.tsx
+++ b/src/components/CustomMessageBody.tsx
@@ -32,7 +32,7 @@ export default function CustomMessageBody(props: Props) {
 
   return (
     <Root>
-      <Text>{sanitizedMessage}</Text>
+      <Text className="sendbird-word">{sanitizedMessage}</Text>
     </Root>
   );
 }

--- a/src/components/DynamicRepliesPanel.tsx
+++ b/src/components/DynamicRepliesPanel.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { useSendMessage } from '../hooks/useSendMessage';
 
-export const ReplyItem = styled.div<SuggestedReplyItemProps>`
+export const ReplyItem = styled.div`
   white-space: nowrap;
   height: 32px;
   font-size: 12px;
@@ -19,7 +19,7 @@ export const ReplyItem = styled.div<SuggestedReplyItemProps>`
     background-color: ${({ theme }) => theme.bgColor.suggestedReply};
     &:hover {
       ${({ theme }) =>
-        `background-color: ${theme.bgColor.hover.suggestedReply};`};
+        `background-color: ${theme.bgColor.hover.suggestedReply}`};
     }
     &:active {
       ${({ theme }) =>

--- a/src/components/DynamicRepliesPanel.tsx
+++ b/src/components/DynamicRepliesPanel.tsx
@@ -1,11 +1,8 @@
 import { useState } from 'react';
-import styled, { type ThemeProps } from 'styled-components';
+import styled from 'styled-components';
 
 import { useSendMessage } from '../hooks/useSendMessage';
 
-interface SuggestedReplyItemProps extends ThemeProps<T> {
-  isActive: boolean;
-}
 export const ReplyItem = styled.div<SuggestedReplyItemProps>`
   white-space: nowrap;
   height: 32px;
@@ -13,31 +10,20 @@ export const ReplyItem = styled.div<SuggestedReplyItemProps>`
   padding: 3px 14px;
   display: flex;
   align-items: center;
+  cursor: pointer;
   && {
     // To override the default color with the self service theme color
-    color: ${({ isActive, theme }: SuggestedReplyItemProps) =>
-      isActive ? theme.textColor.suggestedReply : '#EEEEEE'};
-    border: ${({ isActive, theme }: SuggestedReplyItemProps) =>
-      isActive
-        ? `1px solid ${theme.textColor.suggestedReply}`
-        : '1px solid #EEEEEE'};
+    color: ${({ theme }) => theme.textColor.suggestedReply};
+    border: ${({ theme }) => `1px solid ${theme.textColor.suggestedReply}`};
     border-radius: 18px;
     background-color: ${({ theme }) => theme.bgColor.suggestedReply};
-    cursor: ${(props: SuggestedReplyItemProps) =>
-      props.isActive ? 'pointer' : 'not-allowed'};
     &:hover {
-      ${({ isActive, theme }: SuggestedReplyItemProps) => {
-        if (isActive) {
-          return `background-color: ${theme.bgColor.hover.suggestedReply};`;
-        }
-      }};
+      ${({ theme }) =>
+        `background-color: ${theme.bgColor.hover.suggestedReply};`};
     }
     &:active {
-      ${({ isActive, theme }: SuggestedReplyItemProps) => {
-        if (isActive) {
-          return `background-color: ${theme.textColor.suggestedReply}; color: ${theme.textColor.outgoingMessage};`;
-        }
-      }};
+      ${({ theme }) =>
+        `background-color: ${theme.textColor.suggestedReply}; color: ${theme.textColor.outgoingMessage};`};
     }
   }
 `;
@@ -81,7 +67,6 @@ const DynamicRepliesPanel = (props: Props) => {
             id={option}
             key={option}
             onClick={(e) => onClickReply(e, option)}
-            isActive={true}
           >
             {option}
           </ReplyItem>

--- a/src/components/DynamicRepliesPanel.tsx
+++ b/src/components/DynamicRepliesPanel.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import styled from 'styled-components';
+import styled, { type ThemeProps } from 'styled-components';
 
 import { useSendMessage } from '../hooks/useSendMessage';
 
-interface SuggestedReplyItemProps {
+interface SuggestedReplyItemProps extends ThemeProps<T> {
   isActive: boolean;
 }
 export const ReplyItem = styled.div<SuggestedReplyItemProps>`
@@ -13,29 +13,32 @@ export const ReplyItem = styled.div<SuggestedReplyItemProps>`
   padding: 3px 14px;
   display: flex;
   align-items: center;
-  color: ${({ isActive, theme }: SuggestedReplyItemProps) =>
-    isActive ? theme.textColor.suggestedReply : '#EEEEEE'};
-  border: ${({ isActive, theme }: SuggestedReplyItemProps) =>
-    isActive
-      ? `1px solid ${theme.textColor.suggestedReply}`
-      : '1px solid #EEEEEE'};
-  border-radius: 18px;
-  background-color: ${({ theme }) => theme.bgColor.suggestedReply};
-  cursor: ${(props: SuggestedReplyItemProps) =>
-    props.isActive ? 'pointer' : 'not-allowed'};
-  &:hover {
-    ${({ isActive, theme }: SuggestedReplyItemProps) => {
-      if (isActive) {
-        return `background-color: ${theme.bgColor.hover.suggestedReply};`;
-      }
-    }};
-  }
-  &:active {
-    ${({ isActive, theme }: SuggestedReplyItemProps) => {
-      if (isActive) {
-        return `background-color: ${theme.textColor.suggestedReply}; color: ${theme.textColor.outgoingMessage};`;
-      }
-    }};
+  && {
+    // To override the default color with the self service theme color
+    color: ${({ isActive, theme }: SuggestedReplyItemProps) =>
+      isActive ? theme.textColor.suggestedReply : '#EEEEEE'};
+    border: ${({ isActive, theme }: SuggestedReplyItemProps) =>
+      isActive
+        ? `1px solid ${theme.textColor.suggestedReply}`
+        : '1px solid #EEEEEE'};
+    border-radius: 18px;
+    background-color: ${({ theme }) => theme.bgColor.suggestedReply};
+    cursor: ${(props: SuggestedReplyItemProps) =>
+      props.isActive ? 'pointer' : 'not-allowed'};
+    &:hover {
+      ${({ isActive, theme }: SuggestedReplyItemProps) => {
+        if (isActive) {
+          return `background-color: ${theme.bgColor.hover.suggestedReply};`;
+        }
+      }};
+    }
+    &:active {
+      ${({ isActive, theme }: SuggestedReplyItemProps) => {
+        if (isActive) {
+          return `background-color: ${theme.textColor.suggestedReply}; color: ${theme.textColor.outgoingMessage};`;
+        }
+      }};
+    }
   }
 `;
 
@@ -70,10 +73,11 @@ const DynamicRepliesPanel = (props: Props) => {
   };
 
   return quickReplies && quickReplies.length > 0 ? (
-    <Panel>
+    <Panel className="sendbird-suggested-replies">
       {replyOptions.map((option: string) => {
         return (
           <ReplyItem
+            className="sendbird-suggested-replies__option"
             id={option}
             key={option}
             onClick={(e) => onClickReply(e, option)}

--- a/src/components/StaticRepliesPanel.tsx
+++ b/src/components/StaticRepliesPanel.tsx
@@ -106,11 +106,7 @@ const StaticRepliesPanel = (props: Props) => {
       <Panel>
         {suggestedReplies.map((suggestedReply: SuggestedReply, i: number) => {
           return (
-            <ReplyItem
-              id={i + ''}
-              key={i}
-              onClick={onClickSuggestedReply}
-            >
+            <ReplyItem id={i + ''} key={i} onClick={onClickSuggestedReply}>
               {suggestedReply.title}
             </ReplyItem>
           );

--- a/src/components/StaticRepliesPanel.tsx
+++ b/src/components/StaticRepliesPanel.tsx
@@ -110,7 +110,6 @@ const StaticRepliesPanel = (props: Props) => {
               id={i + ''}
               key={i}
               onClick={onClickSuggestedReply}
-              isActive={true}
             >
               {suggestedReply.title}
             </ReplyItem>

--- a/src/styled-components.d.ts
+++ b/src/styled-components.d.ts
@@ -1,0 +1,6 @@
+import 'styled-components';
+import { type CommonTheme } from './theme';
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends CommonTheme {}
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,5 +1,5 @@
 import { getColorBasedOnSaturation, generateColorVariants } from './colors';
-interface CommonTheme {
+export interface CommonTheme {
   bgColor: {
     chatBottom: string;
     messageInput: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
   "include": [
     "src",
     "./src/custom.d.ts",
-    "node_modules/@sendbird/uikit-react/index.d.ts",
+    "./src/styled-components.d.ts",
   ],
   "exclude": ["node_modules"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
Addresses another requests after #126 mentioned in https://sendbird.slack.com/archives/C0585965FFA/p1711407783540289?thread_ts=1710807877.366899&cid=C0585965FFA

>메시지버블 쪽 같은 경우에 봇 메시지 외에도 suggested reply & user message 쪽 커스텀을 원하시고 있네요 @.@ 'Looking in the code we didn't find a consistent class or id we could use to style that text - is this possible, or not yet?' 에 대한 답을 드릴 수 있을까요?