### PR TITLE
feat: apply text & icon color variation based on theme

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -77,7 +77,7 @@ const SBComponent = () => {
       sdkInitParams={sdkInitParams}
       configureSession={configureSession}
       customExtensionParams={userAgentCustomParams.current}
-      breakPoint={isMobile}
+      breakpoint={isMobile}
       isMentionEnabled={enableMention}
       theme={theme}
       colorSet={customColorSet}

--- a/src/components/ErrorContainer.tsx
+++ b/src/components/ErrorContainer.tsx
@@ -4,7 +4,7 @@ import Label, {
 } from '@sendbird/uikit-react/ui/Label';
 import styled from 'styled-components';
 
-import { ReactComponent as ErrorIcon } from '../icons/icon-error.svg';
+import { ReactComponent as Icon } from '../icons/icon-error.svg';
 
 const Container = styled.div`
   width: 100%;
@@ -17,10 +17,16 @@ const Container = styled.div`
   background-color: ${({ theme }) => theme.bgColor.loadingScreen};
 `;
 
+const ErrorIcon = styled(Icon)`
+  path {
+    fill: ${({ theme }) => theme.textColor.errorMessage};
+  }
+`;
+
 const ErrorMessage = styled(Label)`
   margin-top: 16px;
   text-align: center;
-  color: var(--sendbird-light-onlight-02);
+  color: ${({ theme }) => theme.textColor.errorMessage};
 `;
 
 export default function ErrorContainer({

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -18,6 +18,7 @@ export interface CommonTheme {
   textColor: {
     incomingMessage: string;
     outgoingMessage: string;
+    errorMessage: string;
     sentTime: string;
     sourceInfo: string;
     suggestedReply: string;
@@ -70,6 +71,7 @@ export function getTheme({
         outgoingMessage: accentColor
           ? getColorBasedOnSaturation(accentColor)
           : 'var(--sendbird-light-ondark-01)',
+        errorMessage: 'var(--sendbird-dark-onlight-01)',
         sentTime: 'var(--sendbird-dark-onlight-03)',
         sourceInfo: 'var(--sendbird-light-ondark-01)',
         suggestedReply: accentColor ?? 'var(--sendbird-light-primary-300)',
@@ -110,6 +112,7 @@ export function getTheme({
         incomingMessage: botMessageBGColor
           ? getColorBasedOnSaturation(botMessageBGColor)
           : 'var(--sendbird-dark-ondark-01)',
+        errorMessage: 'var(--sendbird-dark-ondark-01)',
         sentTime: 'var(--sendbird-dark-ondark-03)',
         sourceInfo: 'var(--sendbird-light-ondark-01)',
         suggestedReply: accentColor ?? 'var(--sendbird-dark-primary-200)',


### PR DESCRIPTION
Due to the fixed text color in the error message component, the error message is not really visible in the dark theme.  So I gave different text & icon color to display a proper color on each theme(light / dark).