### PR TITLE
Replace gh-pages deploy target branch temporarily

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - develop
+      - feat/AC-1679 # Will be put develop branch back once QA is done
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
We're doing QA on #140 branch (feat/AC-1679) by deploying github pages to https://sendbird.github.io/chat-ai-widget/. So I'm setting the target branch to `feat/AC-1679` temporarily not to be overwritten by other commits. 