### PR TITLE
feat: drop react-popper-tooltip lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@sendbird/uikit-react": "^3.13.4",
         "@tanstack/react-query": "^5.17.19",
-        "react-popper-tooltip": "^4.4.2",
         "styled-components": "^5.3.11"
       },
       "devDependencies": {
@@ -724,15 +723,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -4858,44 +4848,11 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
-    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "peer": true
-    },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
-    },
-    "node_modules/react-popper-tooltip": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/react-popper-tooltip/-/react-popper-tooltip-4.4.2.tgz",
-      "integrity": "sha512-y48r0mpzysRTZAIh8m2kpZ8S1YPNqGtQPDrlXYSGvDS1c1GpG/NUXbsbIdfbhXfmSaRJuTcaT6N1q3CKuHRVbg==",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@popperjs/core": "^2.11.5",
-        "react-popper": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
@@ -5826,14 +5783,6 @@
       },
       "peerDependencies": {
         "typescript": "*"
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@sendbird/uikit-react": "^3.13.4",
     "@tanstack/react-query": "^5.17.19",
-    "react-popper-tooltip": "^4.4.2",
     "styled-components": "^5.3.11"
   },
   "devDependencies": {

--- a/src/components/BotMessageBottom.tsx
+++ b/src/components/BotMessageBottom.tsx
@@ -1,11 +1,6 @@
-import { useState } from 'react';
-import { createPortal } from 'react-dom';
-import { usePopperTooltip } from 'react-popper-tooltip';
 import styled from 'styled-components';
 
 import { useConstantState } from '../context/ConstantContext';
-import { ReactComponent as InfoIcon } from '../icons/info-icon.svg';
-import 'react-popper-tooltip/dist/styles.css';
 
 const Text = styled.div`
   color: ${({ theme }) => theme.textColor.incomingMessage};
@@ -36,72 +31,23 @@ const Delimiter = styled.div`
   border-top: 1px solid var(--sendbird-light-onlight-04);
 `;
 
-const InfoIconButton = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 18px;
-  cursor: pointer;
-
-  svg {
-    path {
-      fill: ${({ theme }) => theme.textColor.incomingMessage};
-    }
-  }
-`;
-
-const InfoBox = styled.div`
-  padding: 8px 12px;
-  //width: calc(100% - 140px);
-
-  max-width: 260px;
-  width: 100%;
-  background: var(--sendbird-dark-onlight-01);
-  border-radius: 8px;
-  color: ${({ theme }) => theme.textColor.sourceInfo};
-  margin-top: 8px;
-  font-family: 'Roboto', sans-serif;
-  font-size: 14px;
-  line-height: 20px;
-
-  @media screen and (min-width: 600px) {
-    max-width: 400px;
-  }
-`;
-
 export default function BotMessageBottom() {
   const { messageBottomContent } = useConstantState();
-
-  const placement = 'auto';
-
-  const { getTooltipProps, setTooltipRef, setTriggerRef } = usePopperTooltip({
-    placement,
-  });
-
-  const [showInfoBox, setShowInfoBox] = useState<boolean>(false);
+  // const [showInfoBox, setShowInfoBox] = useState<boolean>(true);
 
   return (
     <>
-      <BottomComponent ref={setTriggerRef}>
+      <BottomComponent>
         <Delimiter />
         <TextContainer>
           <Text>{messageBottomContent.text}</Text>
-          <InfoIconButton
+          {/* <InfoIconButton
             onMouseEnter={() => setShowInfoBox(true)}
             onMouseLeave={() => setShowInfoBox(false)}
           >
-            <InfoIcon height={'28px'} width={'28px'} />
-          </InfoIconButton>
+          </InfoIconButton> */}
         </TextContainer>
       </BottomComponent>
-      {showInfoBox &&
-        createPortal(
-          <div ref={setTooltipRef} {...getTooltipProps()}>
-            <InfoBox>{messageBottomContent.infoIconText}</InfoBox>
-            {/*<div {...getArrowProps({ className: 'tooltip-arrow' })} />*/}
-          </div>,
-          document.getElementById('sb_chat_root_for_z_index') as HTMLDivElement
-        )}
     </>
   );
 }


### PR DESCRIPTION
I'm dropping `react-popper-tooltip` library to reduce the size of whole package. 
FYI, `messageBottomContent.infoIconText` is only being used in the docs bot (not in the self service) but we're just displaying "This response is generated by AI and may lack complete accuracy" text in the tooltip. We'd better find another way to display this kind of info instead of using the 3rd party library just for this. 