### PR TITLE
Fix release target branch name format in publish script

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -57,7 +57,7 @@ jobs:
           cat CHANGELOG.md >> temp-changelog.md
           mv temp-changelog.md CHANGELOG.md
           git commit -m "Update CHANGELOG.md for $LATEST_TAG"
-          git push origin v${{ github.event.inputs.version }}
+          git push origin release/v${{ github.event.inputs.version }}
       - name: Update installed chat-ai-widget version to latest under packages/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The format of release branch will be `release/v${version}` (whereas  the tag format is `v${version}`) so I fixed the incorrect one in package-publish.yml github actions workflow file. 