### PR TITLE
feat: disable Datadog temporarily

### DIFF
--- a/src/components/ProviderContainer.tsx
+++ b/src/components/ProviderContainer.tsx
@@ -11,7 +11,7 @@ import {
 } from '../context/ConstantContext';
 import { WidgetOpenProvider } from '../context/WidgetOpenContext';
 import { useChannelStyle } from '../hooks/useChannelStyle';
-import useDatadogRum from '../hooks/useDatadog';
+// import useDatadogRum from '../hooks/useDatadog';
 import useWidgetLocalStorage from '../hooks/useWidgetLocalStorage';
 import { getTheme } from '../theme';
 import { isMobile } from '../utils';
@@ -29,7 +29,7 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
     stringSet,
     ...restConstantProps
   } = useConstantState();
-  useDatadogRum();
+  // useDatadogRum();
 
   const userAgentCustomParams = useRef({
     ...customUserAgentParam,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,13 +32,11 @@ export default defineConfig({
       external: [
         'react',
         'react-dom',
-        '@datadog/browser-rum'
       ],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
-          '@datadog/browser-rum': 'datadogRum'
         }
       }
     }


### PR DESCRIPTION
The bundle size of Datadog rum is quite huge so I think we'd better find another way to load this. I'm commenting out the logic we use the datadog for now until we find the way. 