### PR TITLE
Replace key to contain appId & boId

### DIFF
--- a/src/hooks/useChannelStyle.ts
+++ b/src/hooks/useChannelStyle.ts
@@ -77,12 +77,15 @@ export const useChannelStyle = () => {
         const { bot_style, user, channel } = data;
 
         if (user != null && channel != null) {
-          saveToLocalStorage({
-            expireAt: user.expire_at,
-            userId: user.user_id,
-            sessionToken: user.session_token,
-            channelUrl: channel.channel_url,
-          });
+          saveToLocalStorage(
+            { appId, botId },
+            {
+              expireAt: user.expire_at,
+              userId: user.user_id,
+              sessionToken: user.session_token,
+              channelUrl: channel.channel_url,
+            }
+          );
         }
         return {
           autoOpen: bot_style.auto_open,

--- a/src/hooks/useGroupChannel.ts
+++ b/src/hooks/useGroupChannel.ts
@@ -18,6 +18,7 @@ export const useManualGroupChannelCreation = () => {
     instantConnect,
     firstMessageData,
     createGroupChannelParams,
+    applicationId: appId,
     botId,
     configureSession,
     userId: customUserId,
@@ -56,14 +57,17 @@ export const useManualGroupChannelCreation = () => {
           data: paramData,
         };
         const channel = await sb?.groupChannel?.createChannel(params);
-        saveToLocalStorage({
-          channelUrl: channel.url,
-          expireAt: getDateNDaysLater(30),
-          userId: customUserId,
-          // there's no sessionToken in this case since we don't know the value of it
-          // but instead, it should be handled by configureSession that user provides
-          sessionToken: undefined,
-        });
+        saveToLocalStorage(
+          { appId, botId },
+          {
+            channelUrl: channel.url,
+            expireAt: getDateNDaysLater(30),
+            userId: customUserId,
+            // there's no sessionToken in this case since we don't know the value of it
+            // but instead, it should be handled by configureSession that user provides
+            sessionToken: undefined,
+          }
+        );
       } catch (error) {
         console.error(error);
         throw new Error('Failed to create a new channel');

--- a/src/hooks/useWidgetLocalStorage.ts
+++ b/src/hooks/useWidgetLocalStorage.ts
@@ -1,19 +1,27 @@
 import { useState, useEffect } from 'react';
 
+import { useConstantState } from '../context/ConstantContext';
 import { localStorageHelper } from '../utils';
 
-export const CHAT_AI_WIDGET_LOCAL_STORAGE_KEY = '@sendbird/chat-ai-widget';
+const CHAT_AI_WIDGET_LOCAL_STORAGE_KEY_PREFIX = '@sendbird/chat-ai-widget';
+const getLocalStorageKey = (appId: string, botId: string) => {
+  return `${CHAT_AI_WIDGET_LOCAL_STORAGE_KEY_PREFIX}/${appId}/${botId}`;
+};
 
-export function saveToLocalStorage(value: WidgetLocalStorageValue) {
+export function saveToLocalStorage(
+  key: {
+    appId: string;
+    botId: string;
+  },
+  value: WidgetLocalStorageValue
+) {
+  const localStorageKey = getLocalStorageKey(key.appId, key.botId);
   const stringifiedValue = JSON.stringify(value);
-  localStorageHelper().setItem(
-    CHAT_AI_WIDGET_LOCAL_STORAGE_KEY,
-    stringifiedValue
-  );
+  localStorageHelper().setItem(localStorageKey, stringifiedValue);
   window.dispatchEvent(
     new CustomEvent('localStorageChange', {
       detail: {
-        key: CHAT_AI_WIDGET_LOCAL_STORAGE_KEY,
+        key: localStorageKey,
         value: stringifiedValue,
       },
     })
@@ -38,7 +46,8 @@ function parseValue(value: string | null) {
 }
 
 function useWidgetLocalStorage(): WidgetLocalStorageValue {
-  const key = CHAT_AI_WIDGET_LOCAL_STORAGE_KEY;
+  const { applicationId: appId, botId } = useConstantState();
+  const key = getLocalStorageKey(appId, botId);
   const [value, setValue] = useState(
     () => parseValue(localStorageHelper().getItem(key)) || DEFAULT_VALUE
   );


### PR DESCRIPTION

![Screenshot 2024-04-22 at 3 54 51 PM](https://github.com/sendbird/chat-ai-widget/assets/10060731/c7b567d5-0814-499b-9599-81950e62c57c)

Replaced the chat ai widget's local storage key from `@sendbird/chat-ai-widget` -> `@sendbird/chat-ai-widget/${appId}/${botId}` to handle the Dashboard case (appid & botId can be changed in different app or bot setting) 