### PR TITLE
fix: DOMException issue in useDynamicAttachModal hook

### DIFF
--- a/src/hooks/useDynamicAttachModal.tsx
+++ b/src/hooks/useDynamicAttachModal.tsx
@@ -16,7 +16,7 @@ function useDynamicAttachModal() {
             if (node?.id === parentId) {
               const parent = document.getElementById(parentId);
               const child = document.getElementById(childId);
-              if (parent && child) {
+              if (parent && child && child.parentNode === document.body) {
                 parent.appendChild(child);
                 // Disconnect the observer once the child is attached
                 observer.disconnect();


### PR DESCRIPTION
Fixes https://sendbird.atlassian.net/browse/AC-2093
![Screenshot 2024-04-23 at 1 07 56 PM](https://github.com/sendbird/chat-ai-widget/assets/10060731/02931a28-06e8-49c7-8d80-b5f38daa6b08)

Added one more condition to ensure the child element is still a child of the `document.body` before attempting to append it to the new parent. Confirmed that the issue is gone with this patch. 