### PR TITLE
[AC-2091] Put datadog-rum back with dynamic import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "styled-components": "^5.3.11"
       },
       "devDependencies": {
-        "@datadog/browser-rum": "^5.15.0",
+        "@datadog/browser-rum-slim": "^5.15.0",
         "@types/dompurify": "^3.0.5",
         "@types/react": "^18.0.37",
         "@types/react-dom": "^18.0.11",
@@ -423,36 +423,55 @@
       }
     },
     "node_modules/@datadog/browser-core": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-5.15.0.tgz",
-      "integrity": "sha512-vZeHK0aEqyQqJOal8skaGrGi788Tt+MSP+pH/+J56/Bj4tjLggeIw2SPN+j7XSS+3Q5atk1ZRoEMwvHVV7/s7Q==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-5.16.0.tgz",
+      "integrity": "sha512-8SXjJ034T15ihdYU/9cC1UBKr8aUVAAW8MsL0imll8imjBYo95ZCovbf6e24iZ7hYCdjk26+w3WpHQkARrUNsw==",
       "dev": true
     },
-    "node_modules/@datadog/browser-rum": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-5.15.0.tgz",
-      "integrity": "sha512-bvY8Pgb92uB9+x7oVQTLq5P/fyMBTn+xoEzYJbMmJCEhKL1QPqtYdiRqTNhOLnemZFJ5OaaFNg9az68xJ/O0gg==",
+    "node_modules/@datadog/browser-logs": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-5.16.0.tgz",
+      "integrity": "sha512-9F57SQ1nj67JK1mST9NKUlIAwReIrfEJK6C8LdRzoBA9F4BVVZyQfSbjj/GhMJmdODNP+KWezfGvFflJ58WnJA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "@datadog/browser-core": "5.15.0",
-        "@datadog/browser-rum-core": "5.15.0"
+        "@datadog/browser-core": "5.16.0"
       },
       "peerDependencies": {
-        "@datadog/browser-logs": "5.15.0"
+        "@datadog/browser-rum": "5.16.0"
       },
       "peerDependenciesMeta": {
-        "@datadog/browser-logs": {
+        "@datadog/browser-rum": {
           "optional": true
         }
       }
     },
     "node_modules/@datadog/browser-rum-core": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-5.15.0.tgz",
-      "integrity": "sha512-f8TghTfjEqEo/AexyfM0OCZ3aUOcN6+xg9XRohVC+kmmboo+7GcMLgNfW9zkEoCJvNOheSFN2xPZbNE6iUD3LA==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-5.16.0.tgz",
+      "integrity": "sha512-avG+PRdJuMAAlGu1Ciwru18m/sKGik+XnwujnHMXf85+eSIngMwFlHFTZHDu24F6xq8WaxL53G7cVIGJBx/OUg==",
       "dev": true,
       "dependencies": {
-        "@datadog/browser-core": "5.15.0"
+        "@datadog/browser-core": "5.16.0"
+      }
+    },
+    "node_modules/@datadog/browser-rum-slim": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-slim/-/browser-rum-slim-5.16.0.tgz",
+      "integrity": "sha512-ZyWPYRhjQ26FYq/l5iIQ1cjXYonSCi05hHSGHU/+3Gt6Vu3NuPljTk5FP8GH7R0hJnluXoMDE2pJZjuKd/VnOw==",
+      "dev": true,
+      "dependencies": {
+        "@datadog/browser-core": "5.16.0",
+        "@datadog/browser-rum-core": "5.16.0"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "5.16.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -599,13 +618,13 @@
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -620,11 +639,23 @@
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -633,18 +664,13 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.39.0",
@@ -2075,6 +2101,14 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -5231,6 +5265,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -5425,6 +5471,34 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true
+    },
+    "node_modules/terser": {
+      "version": "5.30.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.4.tgz",
+      "integrity": "sha512-xRdd0v64a8mFK9bnsKVdoNP9GQIKUAaJPTaqEQDL4w/J8WaW4sWXXoMZ+6SimPkfT5bElreXf8m9HnmPc3E1BQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "styled-components": "^5.3.11"
   },
   "devDependencies": {
-    "@datadog/browser-rum": "^5.15.0",
+    "@datadog/browser-rum-slim": "^5.15.0",
     "@types/dompurify": "^3.0.5",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",

--- a/src/components/ProviderContainer.tsx
+++ b/src/components/ProviderContainer.tsx
@@ -5,14 +5,13 @@ import { ThemeProvider } from 'styled-components';
 
 import { ChatAiWidgetProps } from './ChatAiWidget';
 import { generateCSSVariables } from '../colors';
-import { type Constant } from '../const';
 import {
   useConstantState,
   ConstantStateProvider,
 } from '../context/ConstantContext';
 import { WidgetOpenProvider } from '../context/WidgetOpenContext';
 import { useChannelStyle } from '../hooks/useChannelStyle';
-// import useDatadogRum from '../hooks/useDatadog';
+import useDatadogRum from '../hooks/useDatadog';
 import useDynamicAttachModal from '../hooks/useDynamicAttachModal';
 import useWidgetLocalStorage from '../hooks/useWidgetLocalStorage';
 import { getTheme } from '../theme';
@@ -32,8 +31,7 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
     ...restConstantProps
   } = useConstantState();
   useDynamicAttachModal();
-
-  // useDatadogRum();
+  useDatadogRum();
 
   const userAgentCustomParams = useRef({
     ...customUserAgentParam,

--- a/src/hooks/useDatadog.ts
+++ b/src/hooks/useDatadog.ts
@@ -1,4 +1,3 @@
-import { datadogRum } from '@datadog/browser-rum';
 import { useEffect } from 'react';
 
 import { useConstantState } from '../context/ConstantContext';
@@ -12,26 +11,22 @@ const useDatadogRum = () => {
   const { serviceName } = useConstantState();
   useEffect(() => {
     if (DATADOG_APP_ID != null && DATADOG_CLIENT_TOKEN != null) {
-      datadogRum.init({
-        applicationId: DATADOG_APP_ID,
-        clientToken: DATADOG_CLIENT_TOKEN,
-        site: 'datadoghq.com',
-        sessionSampleRate: 100,
-        sessionReplaySampleRate: 100,
-        trackResources: true,
-        trackLongTasks: true,
-        trackUserInteractions: true,
-        service: serviceName || 'genai-chatbot-widget',
-        version: APP_VERSION,
-        env: isProd ? 'production' : 'development',
+      import('@datadog/browser-rum-slim').then(({ datadogRum }) => {
+        datadogRum.init({
+          applicationId: DATADOG_APP_ID,
+          clientToken: DATADOG_CLIENT_TOKEN,
+          site: 'datadoghq.com',
+          sessionSampleRate: 10,
+          sessionReplaySampleRate: 10,
+          trackResources: false,
+          trackLongTasks: false,
+          trackUserInteractions: false,
+          service: serviceName || 'genai-chatbot-widget',
+          version: APP_VERSION,
+          env: isProd ? 'production' : 'development',
+        });
       });
-
-      datadogRum.startSessionReplayRecording();
     }
-
-    return () => {
-      datadogRum.stopSessionReplayRecording();
-    };
   }, []);
 };
 


### PR DESCRIPTION
Addresses https://sendbird.atlassian.net/browse/AC-2091


Two things have been changed ([Sample request log](https://sbchat.datadoghq.com/rum/sessions?query=%40type%3Aview%20%40session.type%3Auser&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AgAAAY8PQRXnuYFrFwAAAAAAAAAYAAAAAEFZOFBRUlhuQUFEMkZPQVVKbzc0bG5JdAAAACQAAAAAMDE4ZjBmNDEtMTVlNy00ODY1LTlmMzMtM2QyZDUyNGRmODdk&fromUser=false&p_tab=attributes&refresh_mode=paused&type=rum&viz=stream&from_ts=1713947820000&to_ts=1713947880000&live=false))
- "@datadog/browser-rum" -> "@datadog/browser-rum-slim"
- Applied dynamic import to split the chunk


- AS-IS 
<img width="476" alt="develop" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/bc58a4c0-b793-4fff-bc73-46ae4a9d4e62">

- TO-BE
<img width="502" alt="Screenshot 2024-04-24 at 5 45 38 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/ad80c272-5aa9-4eb7-8a20-ea694ab783ad">
