### PR TITLE
[AC-2152] Increment specification of custom messageInputWrapper style

### DIFF
--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -51,7 +51,7 @@ const Root = styled.div<RootStyleProps>`
     background-color: ${({ theme }) => theme.bgColor.chatBottom};
   }
 
-  .sendbird-message-input-wrapper__message-input {
+  && .sendbird-message-input-wrapper__message-input {
     padding: 12px 16px;
     display: flex;
     -webkit-box-pack: justify;

--- a/src/components/WidgetWindow.tsx
+++ b/src/components/WidgetWindow.tsx
@@ -71,14 +71,9 @@ const WidgetWindow = ({ children }: { children: React.ReactNode }) => {
   const { isOpen, setIsOpen } = useWidgetOpen();
 
   return (
-    <StyledWidgetWindowWrapper
-      isOpen={isOpen}
-      id={elementIds.widgetWindow}
-    >
+    <StyledWidgetWindowWrapper isOpen={isOpen} id={elementIds.widgetWindow}>
       <StyledCloseButton onClick={() => setIsOpen(false)}>
-        <CloseIcon
-          id={elementIds.closeIcon}
-        />
+        <CloseIcon id={elementIds.closeIcon} />
       </StyledCloseButton>
       {children}
     </StyledWidgetWindowWrapper>


### PR DESCRIPTION
Fixes https://sendbird.atlassian.net/browse/AC-2152

The specification of the styled used to be `0.2.0`
<img width="313" alt="Screenshot 2024-04-25 at 1 18 39 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/f3634d5c-293f-40d5-be62-5d8852b45031">

So I incremented it to `0.3.0`
<img width="306" alt="Screenshot 2024-04-25 at 1 17 22 PM" src="https://github.com/sendbird/chat-ai-widget/assets/10060731/a6443f1c-b369-479a-9eb1-3ae49492458c">
