### PR TITLE
[AC-2203] feat: support dynamic service name

### DIFF
--- a/packages/self-service/src/App.tsx
+++ b/packages/self-service/src/App.tsx
@@ -5,32 +5,28 @@ import {
   ChatAiWidgetConfigs,
 } from '@sendbird/chat-ai-widget';
 
-type ChatbotConfig = Window &
-  typeof globalThis & {
-    chatbotConfig: string[];
-  };
-
-const APP_ID = (window as ChatbotConfig).chatbotConfig?.[0];
-const BOT_ID = (window as ChatbotConfig).chatbotConfig?.[1];
-const chatbotConfigs =
+type AppId = string;
+type BotId = string;
+type ChatbotWindow = typeof window & {
   // Available configs are defined in the ChatAiWidget component
-  ((window as ChatbotConfig)
-    .chatbotConfig?.[2] as unknown as ChatAiWidgetConfigs) ?? {};
+  chatbotConfig?: [AppId, BotId, ChatAiWidgetConfigs];
+};
+
+const [appId, botId, configs] = (window as ChatbotWindow).chatbotConfig ?? [];
 
 function App() {
+  const { serviceName, ...restConfigs } = configs ?? {};
   return (
     <ChatAiWidget
-      applicationId={APP_ID}
-      botId={BOT_ID}
+      applicationId={appId}
+      botId={botId}
       instantConnect={true}
       betaMark={false}
       enableEmojiFeedback={false}
       enableMention={false}
-      customUserAgentParam={{
-        'chat-ai-widget-deployed': 'True',
-      }}
-      serviceName="genai-self-service"
-      {...chatbotConfigs}
+      customUserAgentParam={{ 'chat-ai-widget-deployed': 'True' }}
+      serviceName={serviceName ?? 'genai-self-service'}
+      {...restConfigs}
     />
   );
 }

--- a/packages/self-service/src/App.tsx
+++ b/packages/self-service/src/App.tsx
@@ -3,6 +3,7 @@ import './index.css';
 import {
   ChatAiWidget,
   ChatAiWidgetConfigs,
+  widgetServiceName,
 } from '@sendbird/chat-ai-widget';
 
 type AppId = string;
@@ -25,7 +26,7 @@ function App() {
       enableEmojiFeedback={false}
       enableMention={false}
       customUserAgentParam={{ 'chat-ai-widget-deployed': 'True' }}
-      serviceName={serviceName ?? 'genai-self-service'}
+      serviceName={serviceName ?? widgetServiceName.self.default}
       {...restConfigs}
     />
   );

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -17,7 +17,7 @@ import StaticRepliesPanel from './StaticRepliesPanel';
 import { useConstantState } from '../context/ConstantContext';
 import useAutoDismissMobileKyeboardHandler from '../hooks/useAutoDismissMobileKyeboardHandler';
 import { useScrollOnStreaming } from '../hooks/useScrollOnStreaming';
-import { hideChatBottomBanner, isIOSMobile } from '../utils';
+import { hideChatBottomBanner, isDashboardPreview, isIOSMobile } from '../utils';
 import {
   getBotWelcomeMessages,
   groupMessagesByShortSpanTime,
@@ -108,14 +108,6 @@ const Root = styled.div<RootStyleProps>`
     }
   }
 `;
-
-function isForSendbirdDashboard(data: object | undefined) {
-  return (
-    data &&
-    'chat-ai-widget-preview' in data &&
-    data['chat-ai-widget-preview'] === 'True'
-  );
-}
 
 export function CustomChannelComponent() {
   const {
@@ -243,7 +235,7 @@ export function CustomChannelComponent() {
                 ) : isStaticReplyVisible ? (
                   <StaticRepliesPanel botUser={botUser} />
                 ) : null)}
-              {isForSendbirdDashboard(customUserAgentParam) && message.data && (
+              {isDashboardPreview(customUserAgentParam) && message.data && (
                 <MessageDataContent messageData={message.data} />
               )}
             </Message>

--- a/src/components/ProviderContainer.tsx
+++ b/src/components/ProviderContainer.tsx
@@ -14,7 +14,7 @@ import { useChannelStyle } from '../hooks/useChannelStyle';
 import useDynamicAttachModal from '../hooks/useDynamicAttachModal';
 import useWidgetLocalStorage from '../hooks/useWidgetLocalStorage';
 import { getTheme } from '../theme';
-import { isMobile } from '../utils';
+import { isDashboardPreview, isMobile } from '../utils';
 
 const CHAT_AI_WIDGET_KEY = import.meta.env.VITE_CHAT_AI_WIDGET_KEY;
 
@@ -34,12 +34,18 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
   } = useConstantState();
   useDynamicAttachModal();
 
-  const userAgentCustomParams = useRef<Record<string, string>>({
-    ...customUserAgentParam,
-    'chat-ai-widget': 'True',
-    'chat-ai-widget-key': CHAT_AI_WIDGET_KEY,
-    'chat-ai-widget-service-name': serviceName,
-  });
+  const userAgentCustomParams = useMemo(() => {
+    const userAgent: Record<string, any> = {
+      ...customUserAgentParam,
+      'chat-ai-widget': 'True',
+      'chat-ai-widget-key': CHAT_AI_WIDGET_KEY,
+      'chat-ai-widget-service-name': serviceName,
+    };
+    if (isDashboardPreview(userAgent)) {
+      delete userAgent['chat-ai-widget-service-name'];
+    }
+    return userAgent;
+  }, []);
 
   const { isFetching, theme, accentColor, botMessageBGColor, autoOpen } =
     useChannelStyle();
@@ -83,7 +89,7 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
           customApiHost={apiHost}
           customWebSocketHost={wsHost}
           configureSession={configureSession}
-          customExtensionParams={userAgentCustomParams.current}
+          customExtensionParams={userAgentCustomParams}
           breakpoint={isMobile}
           isMentionEnabled={enableMention}
           theme={theme}

--- a/src/components/ProviderContainer.tsx
+++ b/src/components/ProviderContainer.tsx
@@ -29,14 +29,16 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
     stringSet,
     apiHost,
     wsHost,
+    serviceName,
     ...restConstantProps
   } = useConstantState();
   useDynamicAttachModal();
 
-  const userAgentCustomParams = useRef({
+  const userAgentCustomParams = useRef<Record<string, string>>({
     ...customUserAgentParam,
     'chat-ai-widget': 'True',
     'chat-ai-widget-key': CHAT_AI_WIDGET_KEY,
+    'chat-ai-widget-service-name': serviceName,
   });
 
   const { isFetching, theme, accentColor, botMessageBGColor, autoOpen } =

--- a/src/const.ts
+++ b/src/const.ts
@@ -102,7 +102,7 @@ export interface Constant {
     onClick: () => void;
     isOpen: boolean;
   }) => React.ReactElement;
-  serviceName?: string;
+  serviceName: string;
   callbacks?: SendbirdChatAICallbacks;
 }
 
@@ -162,3 +162,16 @@ export const elementIds = {
   refreshIcon: 'aichatbot-widget-refresh-icon',
   uikitModal: 'sendbird-modal-root',
 };
+
+export const widgetServiceName = {
+  default: 'genai-chatbot-widget',
+  self: {
+    default: 'genai-self-service',
+    wordpress: 'genai-wordpress',
+    shopify: '',
+  },
+  plugin: {
+    wordpress: 'genai-wordpress-plugin',
+    shopify: '',
+  },
+} as const;

--- a/src/const.ts
+++ b/src/const.ts
@@ -167,11 +167,11 @@ export const widgetServiceName = {
   default: 'genai-chatbot-widget',
   self: {
     default: 'genai-self-service',
-    wordpress: 'genai-wordpress',
-    shopify: '',
+    wordpress: 'genai-wordpress-self-service',
+    shopify: 'genai-shopify-self-service',
   },
   plugin: {
     wordpress: 'genai-wordpress-plugin',
-    shopify: '',
+    shopify: 'genai-shopify-plugin',
   },
 } as const;

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -2,6 +2,7 @@ import { LabelStringSet } from '@sendbird/uikit-react/ui/Label';
 import { createContext, useContext, useMemo } from 'react';
 
 import { type Constant, DEFAULT_CONSTANT } from '../const';
+import { getDefaultServiceName } from '../utils';
 
 const initialState = DEFAULT_CONSTANT;
 
@@ -82,7 +83,7 @@ export const ConstantStateProvider = (props: ProviderProps) => {
       enableMobileView: props.enableMobileView ?? initialState.enableMobileView,
       autoOpen: props.autoOpen,
       renderWidgetToggleButton: props.renderWidgetToggleButton,
-      serviceName: props.serviceName,
+      serviceName: props.serviceName ?? getDefaultServiceName(),
       apiHost:
         props.apiHost ?? `https://api-${props.applicationId}.sendbird.com`,
       wsHost: props.wsHost ?? `wss://ws-${props.applicationId}.sendbird.com`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default as ChatAiWidget } from './components/ChatAiWidget';
 export { type ProviderContainerProps as ChatAiWidgetConfigs } from './components/ProviderContainer';
 export { default as ChatWindow } from './components/WidgetWindowExternal';
+export { widgetServiceName } from './const';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -286,6 +286,14 @@ export async function downloadFileWithUrl(url?: string | null) {
   }
 }
 
+export function isDashboardPreview(userAgent: object | undefined) {
+  return (
+    userAgent &&
+    'chat-ai-widget-preview' in userAgent &&
+    userAgent['chat-ai-widget-preview'] === 'True'
+  );
+}
+
 export function getDefaultServiceName() {
   if (isShopify()) return widgetServiceName.self.shopify;
   if (isWordpress()) return widgetServiceName.self.wordpress;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import type SendbirdChat from '@sendbird/chat';
+import { widgetServiceName } from '../const';
 
 export function formatCreatedAtToAMPM(createdAt: number) {
   const date: Date = new Date(createdAt);
@@ -283,4 +284,22 @@ export async function downloadFileWithUrl(url?: string | null) {
     }
     window.open(safeURL, '_blank', 'noopener,noreferrer');
   }
+}
+
+export function getDefaultServiceName() {
+  if (isShopify()) return widgetServiceName.self.shopify;
+  if (isWordpress()) return widgetServiceName.self.wordpress;
+  return widgetServiceName.default;
+}
+
+export function isShopify() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  return typeof window !== 'undefined' && !!window['Shopify'];
+}
+
+export function isWordpress() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  return typeof window !== 'undefined' && !!window['wp'];
 }


### PR DESCRIPTION
- Added serviceName to chatbot configs
  - [service name list and policy](https://docs.google.com/spreadsheets/d/187QwJpyBzAQGFIb-_slunuixu8yI6BbOnr1dwTpEsRo/edit#gid=0)

The service names are as follows. When injecting into plugins that want to be tracked separately, you should inject serviceName.

- If using npm, `genai-chatbot-widget` is used.
- If used as an embedding in a general web environment, `genai-self-service` is used.
- If used as an embedding in a WordPress environment, `genai-wordpress-self-service` is used.
- If used as a plugin in a WordPress environment, `genai-wordpress-plugin` is used.
- If used as an embedding in a Shopify environment, `genai-shopify-self-service` is used.
- If used as a plugin in a Shopify environment, `genai-shopify-plugin` is used.