### PR TITLE
release: v1.5.0

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: 'recursive'
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
@@ -60,8 +62,6 @@ jobs:
           fi
 
       - name: Update installed chat-ai-widget version to latest under packages/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           packages=( "self-service" )
           for package in "${packages[@]}"; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.5.0] (April 30 2024)
+#### Chore:
+- Reduced chat-ai-widget bundle size 402.12 kB -> 292.90 kB (gzip); 27.36%
+  - Removed `@sendbird/uikit-react` dependency from `package.json`.
+  - Linked the necessary code from `sendbird/uikit-react` github repository directly into `packages/uikit/` dir through a Git submodule.
+  - Updated our build process(Github workflow / Circleci config) to initialize and update the Git submodule, ensuring that the latest version of the code is always used.
+
 ## [1.4.7] (April 30 2024)
 #### Feat:
 - Added `serviceName` to chatbot configs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/chat-ai-widget",
-      "version": "1.4.7",
+      "version": "1.5.0",
       "workspaces": [
         "packages/*"
       ],
@@ -38,6 +38,7 @@
         "react-dom": "^18.2.0",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-visualizer": "^5.12.0",
+        "ts-pattern": "^5.1.1",
         "tsc-silent": "^1.2.2",
         "typescript": "5.0.2",
         "vite": "5.2.10",
@@ -37219,6 +37220,12 @@
       "engines": {
         "node": ">=6.10"
       }
+    },
+    "node_modules/ts-pattern": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.1.1.tgz",
+      "integrity": "sha512-i+owkHr5RYdQxj8olUgRrqpiWH9x27PuWVfXwDmJ/n/CoF/SAa7WW1i2oUpPDMQpJ4U+bGRUcZkVq7i1m3zFCg==",
+      "dev": true
     },
     "node_modules/ts-pnp": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5353,11 +5353,13 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.4.7.tgz",
-      "integrity": "sha512-UR/RtrpLGwsSq4Y4O/2cRoCVdLAQzUj80STjAcqd8tywpqOrQZRr34UNk9NXM9lKGbcg8S/PI/J9l3LJSKhuEQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.5.0.tgz",
+      "integrity": "sha512-DfYiaZpHeax1s0GDpI60pD8NZL2k7KT3OsxiX4esuI2+IdmpJ2j8AGt1H7ReSXCQ2UpcgRqNj7fPzXibB4oKRg==",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
-        "@sendbird/uikit-react": "^3.14.3",
         "@tanstack/react-query": "^5.17.19",
         "styled-components": "^5.3.11"
       },
@@ -39667,7 +39669,7 @@
     "packages/self-service": {
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.4.7",
+        "@sendbird/chat-ai-widget": "^1.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -40257,7 +40259,7 @@
     "packages/url-webdemo": {
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.4.7",
+        "@sendbird/chat-ai-widget": "^1.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sendbird/chat-ai-widget.git"
   },
   "scripts": {
-    "install:deps": "npm install && git submodule update --init",
+    "install:deps": "npm install && rm -rf packages/uikit && git submodule update --init",
     "dev": "vite",
     "build:types": "rm -rf dist; rm -rf icons; rm -rf icons; tsc; cp -R src/icons icons; cp -R src/icons dist/icons ; cp -R src/css css; cp -R src/css dist/css",
     "prebuild": "rm -rf ./dist && mv .env .env_temp || true",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-dom": "^18.2.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^5.12.0",
+    "ts-pattern": "^5.1.1",
     "tsc-silent": "^1.2.2",
     "typescript": "5.0.2",
     "vite": "5.2.10",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -15,7 +15,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "^1.4.7",
+    "@sendbird/chat-ai-widget": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/url-webdemo/package.json
+++ b/packages/url-webdemo/package.json
@@ -14,7 +14,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "^1.4.7",
+    "@sendbird/chat-ai-widget": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## [1.5.0] (April 30 2024)
#### Chore:
- Reduced chat-ai-widget bundle size 402.12 kB -> 292.90 kB (gzip); 27.36%
  - Removed `@sendbird/uikit-react` dependency from `package.json`.
  - Linked the necessary code from `sendbird/uikit-react` github repository directly into `packages/uikit/` dir through a Git submodule.
  - Updated our build process(Github workflow / Circleci config) to initialize and update the Git submodule, ensuring that the latest version of the code is always used.
