### PR TITLE
release: v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.5.3] (May 3 2024)
+#### Fix:
+- Fixed errors occurring when removing a channel or when the bot leaves.
+- Fixed types path correctly.
+
 ## [1.5.2] (May 2 2024)
 #### Fix:
 - Fixed an accidental disconnect issue.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/chat-ai-widget",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "workspaces": [
         "packages/*"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5353,9 +5353,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.5.2.tgz",
-      "integrity": "sha512-FDplg09VPdC92zoIzmsiGvhgKZNls7FfCjttxmCqn2HuWuza0l0xUs/RIr+eV2rp4WcuelUZW3gNHBS8+JLsAw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.5.3.tgz",
+      "integrity": "sha512-C+g7Xo5uL/Dd/AXf/fZxwPXCoFLsvZpXiuwqGoqhFCoBu/Axx8wOxnd4ceaAerTmOHE66WoyQQrxEJLEY+qR/A==",
       "workspaces": [
         "packages/*"
       ],
@@ -39669,7 +39669,7 @@
     "packages/self-service": {
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.5.2",
+        "@sendbird/chat-ai-widget": "^1.5.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -15,7 +15,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "^1.5.2",
+    "@sendbird/chat-ai-widget": "^1.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## [1.5.3] (May 3 2024)
#### Fix:
- Fixed errors occurring when removing a channel or when the bot leaves.
- Fixed types path correctly.