### PR TITLE
release/v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.5.4] (May 8 2024)
+
+#### Feat:
+- Added a new optional property `deviceType` to Constant. When given, the app fixates its view type accordingly irregardless of change of screen width
+
+#### Fix:
+- Fixed a bug where initial scroll position is not at the bottom when last message has suggested replies
+- Fixed a bug where margin between neighboring messages is not always `16px`
+- Fixed a bug where users join empty channels when a bot is recreated with the same ID
+- Fixed a bug where modal components being rendered beneath chat component
+
 ## [1.5.3] (May 3 2024)
 #### Fix:
 - Fixed errors occurring when removing a channel or when the bot leaves.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/chat-ai-widget",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "workspaces": [
         "packages/*"
       ],
@@ -5353,9 +5353,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.5.3.tgz",
-      "integrity": "sha512-C+g7Xo5uL/Dd/AXf/fZxwPXCoFLsvZpXiuwqGoqhFCoBu/Axx8wOxnd4ceaAerTmOHE66WoyQQrxEJLEY+qR/A==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.5.4.tgz",
+      "integrity": "sha512-B56ziBPrNQclUlCKkZXPMzNurXRxdwW4W2nfgccxAwAqpRAdnbx1iKYYEDpqYGaz3t+WWClE1pNOFu1RMkoL9A==",
       "workspaces": [
         "packages/*"
       ],
@@ -39665,7 +39665,7 @@
     "packages/self-service": {
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.5.3",
+        "@sendbird/chat-ai-widget": "^1.5.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -15,7 +15,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "^1.5.3",
+    "@sendbird/chat-ai-widget": "^1.5.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## [1.5.4] (May 8 2024)

#### Feat:
- Added a new optional property `fixateView` to Constant. When given, the app fixates its view type accordingly irregardless of change of screen width

#### Fix:
- Fixed a bug where initial scroll position is not at the bottom when last message has suggested replies
- Fixed a bug where margin between neighboring messages is not always `16px`
- Fixed a bug where users join empty channels when a bot is recreated with the same ID
- Fixed a bug where modal components being rendered beneath chat component
