### PR TITLE
[AC-2233] chore: add message filter for business requirements

### DIFF
--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -27,7 +27,7 @@ import {
   getBotWelcomeMessages,
   groupMessagesByShortSpanTime,
   isStaticReplyVisible as getStaticMessageVisibility,
-  shouldFilterMessage,
+  shouldFilterOutMessage,
 } from '../utils/messages';
 
 interface RootStyleProps {
@@ -123,11 +123,16 @@ export function CustomChannelComponent() {
     customUserAgentParam,
   } = useConstantState();
   const {
-    messages: allMessages,
+    messages,
     currentChannel: channel,
     scrollToBottom,
     refresh,
   } = useGroupChannelContext();
+
+  // NOTE: Filter out messages that should not be displayed.
+  const allMessages = messages.filter(
+    (message) => !shouldFilterOutMessage(message)
+  );
 
   const botUser = channel?.members.find((member) => member.userId === botId);
   const lastMessageRef = useRef<HTMLDivElement>(null);
@@ -212,7 +217,8 @@ export function CustomChannelComponent() {
           />
         )}
         renderMessage={({ message, ...props }) => {
-          if (shouldFilterMessage(message)) return <></>;
+          // NOTE: Filter out messages that should not be displayed.
+          if (shouldFilterOutMessage(message)) return <></>;
 
           const grouppedMessage = grouppedMessages.find(
             (m) => m.messageId == message.messageId

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -27,6 +27,7 @@ import {
   getBotWelcomeMessages,
   groupMessagesByShortSpanTime,
   isStaticReplyVisible as getStaticMessageVisibility,
+  shouldFilterMessage,
 } from '../utils/messages';
 
 interface RootStyleProps {
@@ -211,6 +212,8 @@ export function CustomChannelComponent() {
           />
         )}
         renderMessage={({ message, ...props }) => {
+          if (shouldFilterMessage(message)) return <></>;
+
           const grouppedMessage = grouppedMessages.find(
             (m) => m.messageId == message.messageId
           );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,8 +6,6 @@ import { DEFAULT_CONSTANT } from './const';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App
-      firstMessageData={DEFAULT_CONSTANT.firstMessageData}
-    />
+    <App firstMessageData={DEFAULT_CONSTANT.firstMessageData} />
   </React.StrictMode>
 );

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -187,7 +187,7 @@ const messageFilter = {
     return message.message === "The channel's custom_type was updated.";
   },
 };
-export function shouldFilterMessage(message: BaseMessage) {
+export function shouldFilterOutMessage(message: BaseMessage) {
   if (message.isAdminMessage()) {
     return messageFilter.isSystemMessageFromSalesforce(message);
   }

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -184,7 +184,7 @@ export function getSenderUserIdFromMessage(
 
 const messageFilter = {
   isSystemMessageFromSalesforce: (message: AdminMessage) => {
-    return message.message.endsWith('was updated.');
+    return message.message === "The channel's custom_type was updated.";
   },
 };
 export function shouldFilterMessage(message: BaseMessage) {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,4 +1,4 @@
-import { BaseMessage, UserMessage } from '@sendbird/chat/message';
+import { AdminMessage, BaseMessage, UserMessage } from '@sendbird/chat/message';
 
 import { CoreMessageType } from '@uikit/utils';
 
@@ -180,4 +180,16 @@ export function getSenderUserIdFromMessage(
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   return message?.sender?.userId ?? undefined;
+}
+
+const messageFilter = {
+  isSystemMessageFromSalesforce: (message: AdminMessage) => {
+    return message.message.endsWith('was updated.');
+  },
+};
+export function shouldFilterMessage(message: BaseMessage) {
+  if (message.isAdminMessage()) {
+    return messageFilter.isSystemMessageFromSalesforce(message);
+  }
+  return false;
 }

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -182,14 +182,16 @@ export function getSenderUserIdFromMessage(
   return message?.sender?.userId ?? undefined;
 }
 
-const messageFilter = {
-  isSystemMessageFromSalesforce: (message: AdminMessage) => {
-    return message.message === "The channel's custom_type was updated.";
+const msgFilter = {
+  sys: {
+    isCustomTypeUpdated: (message: AdminMessage) => {
+      return message.message === "The channel's custom_type was updated.";
+    },
   },
 };
 export function shouldFilterOutMessage(message: BaseMessage) {
   if (message.isAdminMessage()) {
-    return messageFilter.isSystemMessageFromSalesforce(message);
+    return msgFilter.sys.isCustomTypeUpdated(message);
   }
   return false;
 }


### PR DESCRIPTION
- When connected to the Salesforce connector, there are cases where unintended admin messages appear due to system messages. We are filtering these out.

---
## Before
<img width="356" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/fcdbf5b5-c7d2-438f-8b87-1209e03b1378">

- 불필요한 어드민 메세지가 표기됨 (어드민 메세지로 인해서 suggested replies 가 표시되지 않음)

## After
<img width="357" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/bcdcda25-cec1-4def-88e1-f0d5ef73e1b8">

- 불필요한 어드민 메세지 제거 & suggested replies 표시


ticket: [AC-2233]

[AC-2233]: https://sendbird.atlassian.net/browse/AC-2233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ