### PR TITLE
fix: Fixed a bug where message input is not being disabled when last message has a suggested replies

### DIFF
--- a/src/components/ProviderContainer.tsx
+++ b/src/components/ProviderContainer.tsx
@@ -105,6 +105,7 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
                 },
                 enableVoiceMessage: false,
                 enableFeedback: enableEmojiFeedback,
+                enableSuggestedReplies: true,
               },
             }}
           >


### PR DESCRIPTION
https://sendbird.atlassian.net/browse/AC-2292

### 이슈

마지막 메세지를 아래처럼 업데이트
```
{
    "message_type": "MESG",
    "req_id": "request-1",
    "user_id": "widget_5719f60a72394610ab48e27f934601ae",
    "extended_message_payload": {
        "suggested_replies": [
            "what is sendbird?",
            "you are great!",
            "please give me more details"
        ],
        "disable_chat_input": true
    }
}
```
하면 message input 이 disable 되는걸 기대했는데 안 되고 있었음.

현재 UIKit 이 uikit config 에 `enableSuggestedReplies: true` 가 있으면 UIKit  이 마지막 메세지 (all 로도 설정할수 있음) 에 suggested replies 가 있는 경우, message input 을 disable 하는 로직이 있음. 그러므로 위처럼 메세지를 업뎃하면 message input 이 disabled 되야 함.

### 버그 원인과 픽스
enableSuggestedReplies 설정이 default 가 false 이므로 true 로 넣어줘야 함. 요게 빠져있어서 발생한 이슈임.