### PR TITLE
fix: do not unmount mobile button

### DIFF
--- a/src/components/ChatAiWidget.tsx
+++ b/src/components/ChatAiWidget.tsx
@@ -37,7 +37,7 @@ const MobileComponent = () => {
 
   return (
     <>
-      {!isOpen && <WidgetToggleButton />}
+      <WidgetToggleButton />
       <MobileContainer
         style={{ display: isOpen ? 'block' : 'none' }}
         width={mobileContainerWidth}

--- a/src/components/WidgetToggleButton.tsx
+++ b/src/components/WidgetToggleButton.tsx
@@ -113,7 +113,8 @@ const StyledButton = ({ onClick, accentColor, isOpen }: ToggleButtonProps) => {
 
 export default function WidgetToggleButton() {
   const { isFetching, ...channelStyle } = useChannelStyle();
-  const { autoOpen, renderWidgetToggleButton } = useConstantState();
+  const { autoOpen, renderWidgetToggleButton, isMobileView } =
+    useConstantState();
   const { isOpen, setIsOpen } = useWidgetOpen();
   const timer = useRef<NodeJS.Timeout | null>(null);
 
@@ -136,6 +137,8 @@ export default function WidgetToggleButton() {
     accentColor: channelStyle.accentColor,
     isOpen,
   };
+
+  if (isOpen && isMobileView) return null;
 
   if (typeof renderWidgetToggleButton === 'function') {
     return renderWidgetToggleButton(toggleButtonProps);


### PR DESCRIPTION
- When the chat window is closed on mobile, the button remounts and the autoOpen logic runs again
Modify to hide the button without unmounting it, to prevent the logic from running again