### PR TITLE
release: v1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.6] (May 10 2024)
+#### Fix:
+- Fixed a bug where the widget wouldn't close in the mobile view when autoOpen was set to true.
+
 ## [1.5.5] (May 10 2024)
 #### Feat:
 - Added `botStudioEditProps` in `Constant`. Supports real time update of various injected states such as `botInfo`, `aiAttributes`, `welcomeMessages`, and `styles`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5353,9 +5353,9 @@
       }
     },
     "node_modules/@sendbird/chat-ai-widget": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.5.5.tgz",
-      "integrity": "sha512-fAe9flduGd06LHMGaXKWWSJsnBmpfuXT7Rws3j83mOJyWS85e4oLeq+C+taGSSld0z5p20FDDjOLRpJeHGf2aw==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@sendbird/chat-ai-widget/-/chat-ai-widget-1.5.6.tgz",
+      "integrity": "sha512-WD8aO2dELNF0MCNCGsl3rAJ/vIt2fMRDo4xCxewj+8ktvfxDRaYdTfitrnKoXu+b5gr1tEB+ua1/ZBLrAAh+GQ==",
       "workspaces": [
         "packages/*"
       ],
@@ -39665,7 +39665,7 @@
     "packages/self-service": {
       "version": "0.0.0",
       "dependencies": {
-        "@sendbird/chat-ai-widget": "^1.5.5",
+        "@sendbird/chat-ai-widget": "^1.5.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sendbird/chat-ai-widget",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -15,7 +15,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "^1.5.5",
+    "@sendbird/chat-ai-widget": "^1.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## [1.5.6] (May 10 2024)
#### Fix:
- Fixed a bug where the widget wouldn't close in the mobile view when autoOpen was set to true.
