### PR TITLE
fix: Fixed bot studio issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,12 +70,8 @@ const App = (props: Props) => {
       //   styles: {
       //     theme: 'light',
       //     primaryColor: 'orange',
-      //     botMessageColor: 'hotpink',
+      //     botMessageBGColor: 'hotpink',
       //   },
-      // }}
-      // chatOpenState={false}
-      // onChatOpenStateChange={(props) => {
-      //   console.log('## onChatOpenStateChange: ', props);
       // }}
     />
   );

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -231,11 +231,14 @@ export function CustomChannelComponent() {
            * Replace with injected welcome messages instead.
            */
           if (
+            lastMessage &&
+            botWelcomeMessages.length > 0 &&
             isBotWelcomeMessage &&
             welcomeMessages &&
             welcomeMessages.length > 0
           ) {
             if (!firstMessageId || message.messageId === firstMessageId) {
+              const lastBotWelcomeMessage = botWelcomeMessages[botWelcomeMessages.length - 1];
               return (
                 <InjectedWelcomeMessage
                   lastMessageRef={lastMessageRef}
@@ -243,6 +246,9 @@ export function CustomChannelComponent() {
                   welcomeMessages={welcomeMessages}
                   botUser={botUser}
                   messageCount={messageCount}
+                  isLastMessage={
+                    lastMessage.messageId === lastBotWelcomeMessage.messageId
+                  }
                 />
               );
             }

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -9,13 +9,12 @@ import ChannelUI from '@uikit/modules/GroupChannel/components/GroupChannelUI';
 import Message from '@uikit/modules/GroupChannel/components/Message';
 import { useGroupChannelContext } from '@uikit/modules/GroupChannel/context/GroupChannelProvider';
 
-import BotMessageWithBodyInput from './BotMessageWithBodyInput';
 import ChatBottom from './ChatBottom';
 import CustomChannelHeader from './CustomChannelHeader';
 import CustomMessage from './CustomMessage';
 import DynamicRepliesPanel from './DynamicRepliesPanel';
+import InjectedWelcomeMessage from './InjectedWelcomeMessage';
 import MessageDataContent from './MessageDataContent';
-import ParsedBotMessageBody from './ParsedBotMessageBody';
 import StaticRepliesPanel from './StaticRepliesPanel';
 import { useConstantState } from '../context/ConstantContext';
 import useAutoDismissMobileKyeboardHandler from '../hooks/useAutoDismissMobileKyeboardHandler';
@@ -24,8 +23,6 @@ import {
   hideChatBottomBanner,
   isDashboardPreview,
   isIOSMobile,
-  parseTextMessage,
-  Token,
 } from '../utils';
 import {
   getBotWelcomeMessages,
@@ -126,7 +123,6 @@ export function CustomChannelComponent() {
     enableEmojiFeedback,
     customUserAgentParam,
     botStudioEditProps,
-    replacementTextList,
   } = useConstantState();
   const {
     messages,
@@ -240,43 +236,14 @@ export function CustomChannelComponent() {
             welcomeMessages.length > 0
           ) {
             if (!firstMessageId || message.messageId === firstMessageId) {
-              const lastWelcomeMessageIndex = welcomeMessages.length - 1;
               return (
-                <Message {...props} message={message}>
-                  {welcomeMessages.map((welcomeMsg, index) => {
-                    const suggestedReplies = welcomeMsg.suggestedReplies;
-                    // TODO: support file message in the future.
-                    if ('message' in welcomeMsg) {
-                      const text = welcomeMsg.message;
-                      const tokens: Token[] = parseTextMessage(
-                        text,
-                        replacementTextList
-                      );
-                      return (
-                        <div ref={lastMessageRef} key={index}>
-                          <BotMessageWithBodyInput
-                            chainTop={index === 0}
-                            chainBottom={index === lastWelcomeMessageIndex}
-                            messageCount={messageCount}
-                            botUser={botUser}
-                            bodyComponent={
-                              <ParsedBotMessageBody
-                                text={text}
-                                tokens={tokens}
-                              />
-                            }
-                            createdAt={message.createdAt}
-                          />
-                          {suggestedReplies && suggestedReplies.length && (
-                            <DynamicRepliesPanel
-                              replyOptions={suggestedReplies}
-                            />
-                          )}
-                        </div>
-                      );
-                    }
-                  })}
-                </Message>
+                <InjectedWelcomeMessage
+                  lastMessageRef={lastMessageRef}
+                  messageToReplace={message}
+                  welcomeMessages={welcomeMessages}
+                  botUser={botUser}
+                  messageCount={messageCount}
+                />
               );
             }
             return <></>;

--- a/src/components/CustomMessage.tsx
+++ b/src/components/CustomMessage.tsx
@@ -57,10 +57,12 @@ export default function CustomMessage(props: Props) {
     messageCount,
     message,
   };
-  const { replacementTextList, enableEmojiFeedback } = useConstantState();
+  const { replacementTextList, enableEmojiFeedback, botStudioEditProps } = useConstantState();
   const { stores } = useSendbirdStateContext();
   const { userId } = useWidgetLocalStorage();
   const currentUserId = stores.userStore.user.userId || userId;
+  const { profileUrl } = botStudioEditProps?.botInfo ?? {};
+  const botProfileUrl = profileUrl ?? botUser?.profileUrl ?? '';
 
   // admin message
   if (message.isAdminMessage()) {
@@ -88,7 +90,7 @@ export default function CustomMessage(props: Props) {
       <div>
         {<CurrentUserMessage message={message} />}
         {activeSpinnerId === message.messageId && botUser && (
-          <CustomTypingIndicatorBubble botProfileUrl={botUser.profileUrl} />
+          <CustomTypingIndicatorBubble botProfileUrl={botProfileUrl} />
         )}
       </div>
     );

--- a/src/components/InjectedWelcomeMessage.tsx
+++ b/src/components/InjectedWelcomeMessage.tsx
@@ -1,0 +1,62 @@
+import { Member } from '@sendbird/chat/groupChannel';
+import { RefObject } from 'react';
+
+import Message from '@uikit/modules/GroupChannel/components/Message';
+import { EveryMessage } from '@uikit/types';
+
+import BotMessageWithBodyInput from './BotMessageWithBodyInput';
+import DynamicRepliesPanel from './DynamicRepliesPanel';
+import ParsedBotMessageBody from './ParsedBotMessageBody';
+import { WelcomeUserMessage } from '../const';
+import { useConstantState } from '../context/ConstantContext';
+import { parseTextMessage, Token } from '../utils';
+
+type Props = {
+  lastMessageRef: RefObject<HTMLDivElement>;
+  messageToReplace: EveryMessage;
+  welcomeMessages: WelcomeUserMessage[];
+  botUser: Member | undefined;
+  messageCount: number | undefined;
+};
+
+export default function InjectedWelcomeMessage(props: Props) {
+  const {
+    lastMessageRef,
+    messageToReplace: message,
+    welcomeMessages,
+    botUser,
+    messageCount,
+  } = props;
+  const lastWelcomeMessageIndex = welcomeMessages.length - 1;
+  const { replacementTextList } = useConstantState();
+  return (
+    <Message {...props} message={message}>
+      {welcomeMessages.map((welcomeMsg, index) => {
+        const text = welcomeMsg.message;
+        const tokens: Token[] = parseTextMessage(text, replacementTextList);
+        const suggestedReplies = welcomeMsg.suggestedReplies;
+        // TODO: support file message in the future.
+        if ('message' in welcomeMsg) {
+          const text = welcomeMsg.message;
+          return (
+            <div ref={lastMessageRef} key={index}>
+              <BotMessageWithBodyInput
+                chainTop={index === 0}
+                chainBottom={index === lastWelcomeMessageIndex}
+                botUser={botUser}
+                bodyComponent={
+                  <ParsedBotMessageBody text={text} tokens={tokens} />
+                }
+                createdAt={message.createdAt}
+                messageCount={messageCount}
+              />
+              {suggestedReplies && suggestedReplies.length && (
+                <DynamicRepliesPanel replyOptions={suggestedReplies} />
+              )}
+            </div>
+          );
+        }
+      })}
+    </Message>
+  );
+}

--- a/src/components/InjectedWelcomeMessage.tsx
+++ b/src/components/InjectedWelcomeMessage.tsx
@@ -17,6 +17,7 @@ type Props = {
   welcomeMessages: WelcomeUserMessage[];
   botUser: Member | undefined;
   messageCount: number | undefined;
+  isLastMessage: boolean;
 };
 
 export default function InjectedWelcomeMessage(props: Props) {
@@ -26,6 +27,7 @@ export default function InjectedWelcomeMessage(props: Props) {
     welcomeMessages,
     botUser,
     messageCount,
+    isLastMessage,
   } = props;
   const lastWelcomeMessageIndex = welcomeMessages.length - 1;
   const { replacementTextList } = useConstantState();
@@ -50,7 +52,7 @@ export default function InjectedWelcomeMessage(props: Props) {
                 createdAt={message.createdAt}
                 messageCount={messageCount}
               />
-              {suggestedReplies && suggestedReplies.length && (
+              {isLastMessage && suggestedReplies && suggestedReplies.length && (
                 <DynamicRepliesPanel replyOptions={suggestedReplies} />
               )}
             </div>


### PR DESCRIPTION
### Tickets
- [AC-2358](https://sendbird.atlassian.net/browse/AC-2358)

### Changelogs
- Fixed a bug where `botStudioEditProps.botInfo.profileUrl` is not applied to typing indicator bubble
- Fixed a bug where suggested replies of `botStudioEditProps.welcomeMessages` are not being removed after a message is sent

### What are the issues/goals
- When `botStudioEditProps.botInfo.profileUrl` is given, typing indicator bubble should display the given profile url instead of the actual bot user's profile url.
- Do not show suggested replies of welcome messages if last message is not a welcome message.

### How the issues/goals are fixed/met
- If `botStudioEditProps.botInfo.profileUrl` is given, use that instead in `CustomTypingIndicatorBubble`.
- When `botStudioEditProps.welcomeMessages` is given and has suggested replies, render suggested replies component IFF last message is a welcome message.

### Before demo
[Sendbird AI ChatBot (1).webm](https://github.com/sendbird/chat-ai-widget/assets/16806397/08eb10d0-4f36-41fa-bf3b-3faf3f2a0145)

### After demo
[fix_ Fixed bot studio issues by liamcho · Pull Request #219 · sendbird_chat-ai-widget.webm](https://github.com/sendbird/chat-ai-widget/assets/16806397/7c927864-87b6-4b62-a85f-cf34fc4dba66)


[AC-2358]: https://sendbird.atlassian.net/browse/AC-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ