### PR TITLE
[AC-2362] fix: Allow welcome messages to be displayed even when no messages in channel

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,7 @@ module.exports = {
     'plugin:prettier/recommended',
   ],
   rules: {
+    'react/prop-types': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'off',
     // suppress errors for missing 'import React' in files

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.17.22",
     "@types/dompurify": "^3.0.5",
-    "@types/react": "^18.3.2",
+    "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.60.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.17.22",
     "@types/dompurify": "^3.0.5",
-    "@types/react": "^18.0.37",
+    "@types/react": "^18.3.2",
     "@types/react-dom": "^18.0.11",
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.60.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,10 @@ const App = (props: Props) => {
       //     botMessageBGColor: 'hotpink',
       //   },
       // }}
+      // widgetOpenState={false}
+      // onWidgetOpenStateChange={(props) => {
+      //   console.log('## onChatOpenStateChange: ', props);
+      // }}
     />
   );
 };

--- a/src/components/BotMessageWithBodyInput.tsx
+++ b/src/components/BotMessageWithBodyInput.tsx
@@ -108,7 +108,9 @@ export default function BotMessageWithBodyInput(props: Props) {
         )}
         <Content>
           {bodyComponent}
-          {createdAt && <SentTime>{formatCreatedAtToAMPM(createdAt)}</SentTime>}
+          {!!createdAt && (
+            <SentTime>{formatCreatedAtToAMPM(createdAt)}</SentTime>
+          )}
         </Content>
         {displayProfileImage && messageFeedback}
       </BodyContainer>

--- a/src/components/BotMessageWithBodyInput.tsx
+++ b/src/components/BotMessageWithBodyInput.tsx
@@ -35,7 +35,7 @@ const Content = styled.div`
 
 type Props = {
   botUser?: User;
-  createdAt: number;
+  createdAt?: number;
   messageData?: string;
   bodyComponent: ReactNode;
   chainTop?: boolean;
@@ -108,7 +108,7 @@ export default function BotMessageWithBodyInput(props: Props) {
         )}
         <Content>
           {bodyComponent}
-          <SentTime>{formatCreatedAtToAMPM(createdAt)}</SentTime>
+          {createdAt && <SentTime>{formatCreatedAtToAMPM(createdAt)}</SentTime>}
         </Content>
         {displayProfileImage && messageFeedback}
       </BodyContainer>

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -257,13 +257,17 @@ export function CustomChannelComponent() {
             (mid) => mid === message.messageId
           );
           /**
-           * Filter out messages that should not be displayed.
+           * When welcome messages are given, they are rendered through renderWelcomeMessage. In this case, filter
+           * out actual welcome messages.
            */
           if (
             isWelcomeMessagesGiven &&
             botWelcomeMessageIds.includes(message.messageId)
           )
             return <></>;
+          /**
+           * Filter out any message that should be filtered out due to business requirement.
+           */
           if (shouldFilterOutMessage(message)) return <></>;
           const groupedMessage = groupedMessages.find(
             (m) => m.messageId == message.messageId

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -249,10 +249,8 @@ export function CustomChannelComponent() {
             (mid) => mid === message.messageId
           );
           /**
-           * Note that we display injected welcome messages regardless of first welcome message
-           * is filtered.
+           * Filter out messages that should not be displayed.
            */
-          // NOTE: Filter out messages that should not be displayed.
           if (
             isWelcomeMessagesGiven &&
             botWelcomeMessageIds.includes(message.messageId)
@@ -263,7 +261,6 @@ export function CustomChannelComponent() {
             (m) => m.messageId == message.messageId
           );
 
-          /* eslint-disable react/prop-types */ // TODO: upgrade to latest eslint tooling or add "react/prop-types": "off" to eslintrc rules.
           let hasSeparator = props.hasSeparator;
           const prevMessageTimestamp =
             lastWelcomeMessageCreatedAt ?? firstMessageCreatedAt;

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -207,7 +207,7 @@ export function CustomChannelComponent() {
   const botWelcomeMessageIds = botWelcomeMessages.map(
     (message) => message.messageId
   );
-  const firstMessageCreatedAt = allMessages[0]?.createdAt : undefined;
+  const firstMessageCreatedAt = allMessages[0]?.createdAt;
   const lastWelcomeMessageCreatedAt = botWelcomeMessages[botWelcomeMessages.length - 1]?.createdAt
   const isWelcomeMessagesGiven = welcomeMessages && welcomeMessages.length > 0;
 

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -1,5 +1,6 @@
 import { SendableMessage } from '@sendbird/chat/lib/__definition';
 import { SendingStatus, UserMessage } from '@sendbird/chat/message';
+import isSameDay from 'date-fns/isSameDay';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
@@ -13,9 +14,9 @@ import ChatBottom from './ChatBottom';
 import CustomChannelHeader from './CustomChannelHeader';
 import CustomMessage from './CustomMessage';
 import DynamicRepliesPanel from './DynamicRepliesPanel';
-import InjectedWelcomeMessage from './InjectedWelcomeMessage';
 import MessageDataContent from './MessageDataContent';
 import StaticRepliesPanel from './StaticRepliesPanel';
+import WelcomeMessages from './WelcomeMessages';
 import { useConstantState } from '../context/ConstantContext';
 import useAutoDismissMobileKyeboardHandler from '../hooks/useAutoDismissMobileKyeboardHandler';
 import { useResetHistoryOnConnected } from '../hooks/useResetHistoryOnConnected';
@@ -201,11 +202,18 @@ export function CustomChannelComponent() {
 
   const botWelcomeMessages = useMemo(() => {
     if (!botId) return [];
-    return getBotWelcomeMessages(allMessages, botId);
+    return getBotWelcomeMessages(messages, botId);
   }, [messageCount]);
-
-  const firstMessageId =
-    allMessages.length > 0 ? allMessages[0].messageId : null;
+  const botWelcomeMessageIds = botWelcomeMessages.map(
+    (message) => message.messageId
+  );
+  const firstMessageCreatedAt =
+    allMessages.length > 0 ? allMessages[0].createdAt : undefined;
+  const lastWelcomeMessageCreatedAt =
+    botWelcomeMessages.length > 0
+      ? botWelcomeMessages[botWelcomeMessages.length - 1].createdAt
+      : undefined;
+  const isWelcomeMessagesGiven = welcomeMessages && welcomeMessages.length > 0;
 
   return (
     <Root height={'100%'} isStaticReplyVisible={isStaticReplyVisible}>
@@ -224,50 +232,51 @@ export function CustomChannelComponent() {
             }}
           />
         )}
-        renderMessage={({ message, ...props }) => {
-          const isBotWelcomeMessage = botWelcomeMessages.some(
-            (m) => m.messageId === message.messageId
-          );
-          /**
-           * Replace with injected welcome messages instead.
-           */
-          if (
-            lastMessage &&
-            botWelcomeMessages.length > 0 &&
-            isBotWelcomeMessage &&
-            welcomeMessages &&
-            welcomeMessages.length > 0
-          ) {
-            if (!firstMessageId || message.messageId === firstMessageId) {
-              const lastBotWelcomeMessage =
-                botWelcomeMessages[botWelcomeMessages.length - 1];
-              return (
-                <InjectedWelcomeMessage
-                  lastMessageRef={lastMessageRef}
-                  messageToReplace={message}
+        renderWelcomeMessage={
+          channel && isWelcomeMessagesGiven && botUser
+            ? () => (
+                <WelcomeMessages
+                  channel={channel}
                   welcomeMessages={welcomeMessages}
                   botUser={botUser}
                   messageCount={messageCount}
-                  isLastMessage={
-                    lastMessage.messageId === lastBotWelcomeMessage.messageId
+                  lastMessageRef={lastMessageRef}
+                  timestamp={
+                    lastWelcomeMessageCreatedAt ?? firstMessageCreatedAt
                   }
                 />
-              );
-            }
-            return <></>;
-          }
+              )
+            : undefined
+        }
+        renderMessage={({ message, ...props }) => {
+          const isBotWelcomeMessage = botWelcomeMessageIds.some(
+            (mid) => mid === message.messageId
+          );
           /**
            * Note that we display injected welcome messages regardless of first welcome message
            * is filtered.
            */
           // NOTE: Filter out messages that should not be displayed.
+          if (
+            isWelcomeMessagesGiven &&
+            botWelcomeMessageIds.includes(message.messageId)
+          )
+            return <></>;
           if (shouldFilterOutMessage(message)) return <></>;
           const groupedMessage = groupedMessages.find(
             (m) => m.messageId == message.messageId
           );
 
+          /* eslint-disable react/prop-types */ // TODO: upgrade to latest eslint tooling or add "react/prop-types": "off" to eslintrc rules.
+          let hasSeparator = props.hasSeparator;
+          const prevMessageTimestamp =
+            lastWelcomeMessageCreatedAt ?? firstMessageCreatedAt;
+          if (isWelcomeMessagesGiven && prevMessageTimestamp) {
+            hasSeparator = !isSameDay(message.createdAt, prevMessageTimestamp);
+          }
+
           return (
-            <Message {...props} message={message}>
+            <Message {...props} hasSeparator={hasSeparator} message={message}>
               <div
                 style={
                   message.messageId !== lastMessage?.messageId

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -16,7 +16,7 @@ import CustomMessage from './CustomMessage';
 import DynamicRepliesPanel from './DynamicRepliesPanel';
 import MessageDataContent from './MessageDataContent';
 import StaticRepliesPanel from './StaticRepliesPanel';
-import WelcomeMessages from './WelcomeMessages';
+import WelcomeMessages from './messages/WelcomeMessages';
 import { useConstantState } from '../context/ConstantContext';
 import useAutoDismissMobileKyeboardHandler from '../hooks/useAutoDismissMobileKyeboardHandler';
 import { useResetHistoryOnConnected } from '../hooks/useResetHistoryOnConnected';

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -240,10 +240,7 @@ export function CustomChannelComponent() {
                   messageCount={messageCount}
                   lastMessageRef={lastMessageRef}
                   showSuggestedReplies={
-                    lastMessage
-                      ? lastMessage.messageId ===
-                        lastBotWelcomeMessage.messageId
-                      : true
+                    lastMessage?.messageId === lastBotWelcomeMessage?.messageId
                   }
                   timestamp={
                     lastWelcomeMessageCreatedAt ?? firstMessageCreatedAt

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -208,7 +208,9 @@ export function CustomChannelComponent() {
     (message) => message.messageId
   );
   const firstMessageCreatedAt = allMessages[0]?.createdAt;
-  const lastWelcomeMessageCreatedAt = botWelcomeMessages[botWelcomeMessages.length - 1]?.createdAt
+  const lastBotWelcomeMessage =
+    botWelcomeMessages[botWelcomeMessages.length - 1];
+  const lastWelcomeMessageCreatedAt = lastBotWelcomeMessage?.createdAt;
   const isWelcomeMessagesGiven = welcomeMessages && welcomeMessages.length > 0;
 
   return (
@@ -237,6 +239,12 @@ export function CustomChannelComponent() {
                   botUser={botUser}
                   messageCount={messageCount}
                   lastMessageRef={lastMessageRef}
+                  showSuggestedReplies={
+                    lastMessage
+                      ? lastMessage.messageId ===
+                        lastBotWelcomeMessage.messageId
+                      : true
+                  }
                   timestamp={
                     lastWelcomeMessageCreatedAt ?? firstMessageCreatedAt
                   }

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -209,10 +209,7 @@ export function CustomChannelComponent() {
   );
   const firstMessageCreatedAt =
     allMessages.length > 0 ? allMessages[0].createdAt : undefined;
-  const lastWelcomeMessageCreatedAt =
-    botWelcomeMessages.length > 0
-      ? botWelcomeMessages[botWelcomeMessages.length - 1].createdAt
-      : undefined;
+  const lastWelcomeMessageCreatedAt = botWelcomeMessages[botWelcomeMessages.length - 1]?.createdAt
   const isWelcomeMessagesGiven = welcomeMessages && welcomeMessages.length > 0;
 
   return (

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -207,8 +207,7 @@ export function CustomChannelComponent() {
   const botWelcomeMessageIds = botWelcomeMessages.map(
     (message) => message.messageId
   );
-  const firstMessageCreatedAt =
-    allMessages.length > 0 ? allMessages[0].createdAt : undefined;
+  const firstMessageCreatedAt = allMessages[0]?.createdAt : undefined;
   const lastWelcomeMessageCreatedAt = botWelcomeMessages[botWelcomeMessages.length - 1]?.createdAt
   const isWelcomeMessagesGiven = welcomeMessages && welcomeMessages.length > 0;
 

--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -202,7 +202,7 @@ export function CustomChannelComponent() {
 
   const botWelcomeMessages = useMemo(() => {
     if (!botId) return [];
-    return getBotWelcomeMessages(messages, botId);
+    return getBotWelcomeMessages(allMessages, botId);
   }, [messageCount]);
   const botWelcomeMessageIds = botWelcomeMessages.map(
     (message) => message.messageId

--- a/src/components/WelcomeMessages.tsx
+++ b/src/components/WelcomeMessages.tsx
@@ -1,0 +1,88 @@
+import { ChannelType, User } from '@sendbird/chat';
+import type { GroupChannel } from '@sendbird/chat/groupChannel';
+import {
+  MessageType,
+  SendingStatus,
+  UserMessage,
+} from '@sendbird/chat/message';
+import { RefObject } from 'react';
+
+import useSendbirdStateContext from '@uikit/hooks/useSendbirdStateContext';
+import Message from '@uikit/modules/GroupChannel/components/Message';
+import { ClientUserMessage } from '@uikit/types';
+
+import BotMessageWithBodyInput from './BotMessageWithBodyInput';
+import DynamicRepliesPanel from './DynamicRepliesPanel';
+import ParsedBotMessageBody from './ParsedBotMessageBody';
+import { WelcomeUserMessage } from '../const';
+import { useConstantState } from '../context/ConstantContext';
+import { parseTextMessage, Token } from '../utils';
+
+interface WelcomeMessagesProps {
+  channel: GroupChannel;
+  welcomeMessages: WelcomeUserMessage[];
+  botUser: User;
+  messageCount: number;
+  lastMessageRef: RefObject<HTMLDivElement>;
+  timestamp?: number;
+}
+
+export default function WelcomeMessages(props: WelcomeMessagesProps) {
+  const { replacementTextList } = useConstantState();
+  const {
+    channel,
+    welcomeMessages,
+    botUser,
+    messageCount,
+    lastMessageRef,
+    timestamp,
+  } = props;
+  const lastWelcomeMessageIndex = welcomeMessages.length - 1;
+
+  const store = useSendbirdStateContext();
+  const sb = store.stores.sdkStore.sdk;
+  const createdAt = timestamp ?? Date.now(); // channel.createdAt;
+  const localMessage: UserMessage = sb.message.buildMessageFromSerializedData({
+    messageId: channel.createdAt,
+    channelUrl: channel.url,
+    channelType: ChannelType.GROUP,
+    createdAt, // FIXME: ms? or seconds? sorted by this or id?
+    sender: botUser?.serialize(),
+    sendingStatus: SendingStatus.SUCCEEDED,
+    messageType: MessageType.USER,
+    message: 'a welcome message',
+    reactions: [],
+    plugins: [],
+  }) as UserMessage;
+
+  return (
+    <Message message={localMessage as ClientUserMessage} hasSeparator={true}>
+      {welcomeMessages.map((welcomeMsg: WelcomeUserMessage, index) => {
+        const suggestedReplies = welcomeMsg.suggestedReplies;
+        if ('message' in welcomeMsg) {
+          const text = welcomeMsg.message;
+          const tokens: Token[] = parseTextMessage(text, replacementTextList);
+          return (
+            <div ref={lastMessageRef} key={index}>
+              <BotMessageWithBodyInput
+                chainTop={index === 0}
+                chainBottom={index === lastWelcomeMessageIndex}
+                messageCount={messageCount}
+                botUser={botUser}
+                bodyComponent={
+                  <ParsedBotMessageBody text={text} tokens={tokens} />
+                }
+              />
+              {suggestedReplies && suggestedReplies.length && (
+                <DynamicRepliesPanel replyOptions={suggestedReplies} />
+              )}
+            </div>
+          );
+        } else {
+          // TODO: support file message in the future.
+          return <></>;
+        }
+      })}
+    </Message>
+  );
+}

--- a/src/components/WelcomeMessages.tsx
+++ b/src/components/WelcomeMessages.tsx
@@ -47,7 +47,7 @@ export default function WelcomeMessages(props: WelcomeMessagesProps) {
     channelUrl: channel.url,
     channelType: ChannelType.GROUP,
     createdAt, // FIXME: ms? or seconds? sorted by this or id?
-    sender: botUser?.serialize(),
+    sender: botUser.serialize(),
     sendingStatus: SendingStatus.SUCCEEDED,
     messageType: MessageType.USER,
     message: 'a welcome message',

--- a/src/components/messages/WelcomeMessages.tsx
+++ b/src/components/messages/WelcomeMessages.tsx
@@ -3,9 +3,8 @@ import type { GroupChannel } from '@sendbird/chat/groupChannel';
 import {
   MessageType,
   SendingStatus,
-  UserMessage,
 } from '@sendbird/chat/message';
-import { RefObject } from 'react';
+import { RefObject, useMemo } from 'react';
 
 import useSendbirdStateContext from '@uikit/hooks/useSendbirdStateContext';
 import Message from '@uikit/modules/GroupChannel/components/Message';
@@ -44,21 +43,25 @@ export default function WelcomeMessages(props: WelcomeMessagesProps) {
   const store = useSendbirdStateContext();
   const sb = store.stores.sdkStore.sdk;
   const createdAt = timestamp ?? Date.now(); // channel.createdAt;
-  const localMessage: UserMessage = sb.message.buildMessageFromSerializedData({
-    messageId: channel.createdAt,
-    channelUrl: channel.url,
-    channelType: ChannelType.GROUP,
-    createdAt, // FIXME: ms? or seconds? sorted by this or id?
-    sender: botUser.serialize(),
-    sendingStatus: SendingStatus.SUCCEEDED,
-    messageType: MessageType.USER,
-    message: 'a welcome message',
-    reactions: [],
-    plugins: [],
-  }) as UserMessage;
+  const localMessage: ClientUserMessage = useMemo(
+    () =>
+      sb.message.buildMessageFromSerializedData({
+        messageId: channel.createdAt,
+        channelUrl: channel.url,
+        channelType: ChannelType.GROUP,
+        createdAt, // FIXME: ms? or seconds? sorted by this or id?
+        sender: botUser.serialize(),
+        sendingStatus: SendingStatus.SUCCEEDED,
+        messageType: MessageType.USER,
+        message: 'a welcome message',
+        reactions: [],
+        plugins: [],
+      }) as ClientUserMessage,
+    []
+  );
 
   return (
-    <Message message={localMessage as ClientUserMessage} hasSeparator={true}>
+    <Message message={localMessage} hasSeparator={true}>
       {welcomeMessages.map((welcomeMsg, index) => {
         const suggestedReplies = welcomeMsg.suggestedReplies;
         if ('message' in welcomeMsg) {

--- a/src/components/messages/WelcomeMessages.tsx
+++ b/src/components/messages/WelcomeMessages.tsx
@@ -11,12 +11,12 @@ import useSendbirdStateContext from '@uikit/hooks/useSendbirdStateContext';
 import Message from '@uikit/modules/GroupChannel/components/Message';
 import { ClientUserMessage } from '@uikit/types';
 
-import BotMessageWithBodyInput from '../BotMessageWithBodyInput';
-import DynamicRepliesPanel from '../DynamicRepliesPanel';
-import ParsedBotMessageBody from '../ParsedBotMessageBody';
 import { WelcomeUserMessage } from '../../const';
 import { useConstantState } from '../../context/ConstantContext';
 import { parseTextMessage, Token } from '../../utils';
+import BotMessageWithBodyInput from '../BotMessageWithBodyInput';
+import DynamicRepliesPanel from '../DynamicRepliesPanel';
+import ParsedBotMessageBody from '../ParsedBotMessageBody';
 
 interface WelcomeMessagesProps {
   channel: GroupChannel;
@@ -24,6 +24,7 @@ interface WelcomeMessagesProps {
   botUser: User;
   messageCount: number;
   lastMessageRef: RefObject<HTMLDivElement>;
+  showSuggestedReplies: boolean;
   timestamp?: number;
 }
 
@@ -35,6 +36,7 @@ export default function WelcomeMessages(props: WelcomeMessagesProps) {
     botUser,
     messageCount,
     lastMessageRef,
+    showSuggestedReplies,
     timestamp,
   } = props;
   const lastWelcomeMessageIndex = welcomeMessages.length - 1;
@@ -73,9 +75,11 @@ export default function WelcomeMessages(props: WelcomeMessagesProps) {
                   <ParsedBotMessageBody text={text} tokens={tokens} />
                 }
               />
-              {suggestedReplies && suggestedReplies.length && (
-                <DynamicRepliesPanel replyOptions={suggestedReplies} />
-              )}
+              {showSuggestedReplies &&
+                suggestedReplies &&
+                suggestedReplies.length && (
+                  <DynamicRepliesPanel replyOptions={suggestedReplies} />
+                )}
             </div>
           );
         } else {

--- a/src/components/messages/WelcomeMessages.tsx
+++ b/src/components/messages/WelcomeMessages.tsx
@@ -11,12 +11,12 @@ import useSendbirdStateContext from '@uikit/hooks/useSendbirdStateContext';
 import Message from '@uikit/modules/GroupChannel/components/Message';
 import { ClientUserMessage } from '@uikit/types';
 
-import BotMessageWithBodyInput from './BotMessageWithBodyInput';
-import DynamicRepliesPanel from './DynamicRepliesPanel';
-import ParsedBotMessageBody from './ParsedBotMessageBody';
-import { WelcomeUserMessage } from '../const';
-import { useConstantState } from '../context/ConstantContext';
-import { parseTextMessage, Token } from '../utils';
+import BotMessageWithBodyInput from '../BotMessageWithBodyInput';
+import DynamicRepliesPanel from '../DynamicRepliesPanel';
+import ParsedBotMessageBody from '../ParsedBotMessageBody';
+import { WelcomeUserMessage } from '../../const';
+import { useConstantState } from '../../context/ConstantContext';
+import { parseTextMessage, Token } from '../../utils';
 
 interface WelcomeMessagesProps {
   channel: GroupChannel;

--- a/src/components/messages/WelcomeMessages.tsx
+++ b/src/components/messages/WelcomeMessages.tsx
@@ -59,7 +59,7 @@ export default function WelcomeMessages(props: WelcomeMessagesProps) {
 
   return (
     <Message message={localMessage as ClientUserMessage} hasSeparator={true}>
-      {welcomeMessages.map((welcomeMsg: WelcomeUserMessage, index) => {
+      {welcomeMessages.map((welcomeMsg, index) => {
         const suggestedReplies = welcomeMsg.suggestedReplies;
         if ('message' in welcomeMsg) {
           const text = welcomeMsg.message;

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useContext } from 'react';
+import { createContext, PropsWithChildren, useContext, useMemo } from 'react';
 
 import { LabelStringSet } from '@uikit/ui/Label';
 
@@ -23,88 +23,87 @@ export const ConstantStateProvider = (
 ) => {
   const isMobileView = isMobile(props.deviceType);
   const defaultRefreshComponentSideLength = isMobileView ? '24px' : '16px';
-
+  const memoizedValue = useMemo(
+    () => ({
+      applicationId: props.applicationId,
+      botId: props.botId,
+      botNickName: props.botNickName ?? initialState.botNickName,
+      userNickName: props.userNickName ?? initialState.userNickName,
+      betaMark: props.betaMark ?? initialState.betaMark,
+      customBetaMarkText:
+        props.customBetaMarkText ?? initialState.customBetaMarkText,
+      suggestedMessageContent: {
+        replyContents:
+          props.suggestedMessageContent?.replyContents ??
+          initialState.suggestedMessageContent.replyContents,
+        messageFilterList:
+          props.suggestedMessageContent?.messageFilterList ??
+          initialState.suggestedMessageContent.messageFilterList,
+      },
+      callbacks: props.callbacks,
+      firstMessageData: props.firstMessageData ?? [],
+      createGroupChannelParams:
+        props.createGroupChannelParams ?? initialState.createGroupChannelParams,
+      chatBottomContent:
+        props.chatBottomContent ?? initialState.chatBottomContent,
+      messageBottomContent:
+        props.messageBottomContent ?? initialState.messageBottomContent,
+      replacementTextList:
+        props.replacementTextList ?? initialState.replacementTextList,
+      instantConnect: props.instantConnect ?? initialState.instantConnect,
+      customRefreshComponent: {
+        icon:
+          props.customRefreshComponent?.icon ??
+          initialState.customRefreshComponent.icon,
+        width:
+          props.customRefreshComponent?.width ??
+          defaultRefreshComponentSideLength,
+        height:
+          props.customRefreshComponent?.height ??
+          defaultRefreshComponentSideLength,
+        onClick:
+          props.customRefreshComponent?.onClick ??
+          initialState.customRefreshComponent.onClick,
+        style: {
+          ...initialState.customRefreshComponent.style,
+          ...props.customRefreshComponent?.style,
+        },
+      },
+      customUserAgentParam: props.customUserAgentParam,
+      /**
+       * userId & configureSession should be used together to create a group channel on the client side.
+       */
+      userId: props.userId,
+      configureSession: props.configureSession,
+      stringSet: {
+        ...LabelStringSet,
+        ...props.stringSet,
+      },
+      enableSourceMessage:
+        props.enableSourceMessage ?? initialState.enableSourceMessage,
+      enableEmojiFeedback:
+        props.enableEmojiFeedback ?? initialState.enableEmojiFeedback,
+      enableMention: props.enableMention ?? initialState.enableMention,
+      enableMobileView: props.enableMobileView ?? initialState.enableMobileView,
+      autoOpen: props.autoOpen,
+      renderWidgetToggleButton: props.renderWidgetToggleButton,
+      serviceName: getDefaultServiceName(props.serviceName),
+      apiHost:
+        props.apiHost ?? `https://api-${props.applicationId}.sendbird.com`,
+      wsHost: props.wsHost ?? `wss://ws-${props.applicationId}.sendbird.com`,
+      deviceType: props.deviceType, // Note this property is not being used but added just to remove any confusion.
+      isMobileView,
+      botStudioEditProps: props.botStudioEditProps,
+      widgetOpenState: props.widgetOpenState,
+      onWidgetOpenStateChange: props.onWidgetOpenStateChange,
+      enableResetHistoryOnConnect:
+        props.enableResetHistoryOnConnect ??
+        initialState.enableResetHistoryOnConnect,
+    }),
+    [props]
+  );
   return (
-    <ConstantContext.Provider
-      value={{
-        applicationId: props.applicationId,
-        botId: props.botId,
-        botNickName: props.botNickName ?? initialState.botNickName,
-        userNickName: props.userNickName ?? initialState.userNickName,
-        betaMark: props.betaMark ?? initialState.betaMark,
-        customBetaMarkText:
-          props.customBetaMarkText ?? initialState.customBetaMarkText,
-        suggestedMessageContent: {
-          replyContents:
-            props.suggestedMessageContent?.replyContents ??
-            initialState.suggestedMessageContent.replyContents,
-          messageFilterList:
-            props.suggestedMessageContent?.messageFilterList ??
-            initialState.suggestedMessageContent.messageFilterList,
-        },
-        callbacks: props.callbacks,
-        firstMessageData: props.firstMessageData ?? [],
-        createGroupChannelParams:
-          props.createGroupChannelParams ??
-          initialState.createGroupChannelParams,
-        chatBottomContent:
-          props.chatBottomContent ?? initialState.chatBottomContent,
-        messageBottomContent:
-          props.messageBottomContent ?? initialState.messageBottomContent,
-        replacementTextList:
-          props.replacementTextList ?? initialState.replacementTextList,
-        instantConnect: props.instantConnect ?? initialState.instantConnect,
-        customRefreshComponent: {
-          icon:
-            props.customRefreshComponent?.icon ??
-            initialState.customRefreshComponent.icon,
-          width:
-            props.customRefreshComponent?.width ??
-            defaultRefreshComponentSideLength,
-          height:
-            props.customRefreshComponent?.height ??
-            defaultRefreshComponentSideLength,
-          onClick:
-            props.customRefreshComponent?.onClick ??
-            initialState.customRefreshComponent.onClick,
-          style: {
-            ...initialState.customRefreshComponent.style,
-            ...props.customRefreshComponent?.style,
-          },
-        },
-        customUserAgentParam: props.customUserAgentParam,
-        /**
-         * userId & configureSession should be used together to create a group channel on the client side.
-         */
-        userId: props.userId,
-        configureSession: props.configureSession,
-        stringSet: {
-          ...LabelStringSet,
-          ...props.stringSet,
-        },
-        enableSourceMessage:
-          props.enableSourceMessage ?? initialState.enableSourceMessage,
-        enableEmojiFeedback:
-          props.enableEmojiFeedback ?? initialState.enableEmojiFeedback,
-        enableMention: props.enableMention ?? initialState.enableMention,
-        enableMobileView:
-          props.enableMobileView ?? initialState.enableMobileView,
-        autoOpen: props.autoOpen,
-        renderWidgetToggleButton: props.renderWidgetToggleButton,
-        serviceName: getDefaultServiceName(props.serviceName),
-        apiHost:
-          props.apiHost ?? `https://api-${props.applicationId}.sendbird.com`,
-        wsHost: props.wsHost ?? `wss://ws-${props.applicationId}.sendbird.com`,
-        deviceType: props.deviceType, // Note this property is not being used but added just to remove any confusion.
-        isMobileView,
-        botStudioEditProps: props.botStudioEditProps,
-        widgetOpenState: props.widgetOpenState,
-        onWidgetOpenStateChange: props.onWidgetOpenStateChange,
-        enableResetHistoryOnConnect:
-          props.enableResetHistoryOnConnect ??
-          initialState.enableResetHistoryOnConnect,
-      }}
-    >
+    <ConstantContext.Provider value={memoizedValue}>
       {props.children}
     </ConstantContext.Provider>
   );


### PR DESCRIPTION
### What changed?

#### Before
- Given welcome messages are displayed only when there is at least one actual welcome message in the channel.

#### After
- Given welcome messages are displayed event when no messages in the channel.

### Changelog
- Fixed a bug where injected welcome messages are not displayed when there is no message in the channel


### Ticket
https://sendbird.atlassian.net/browse/AC-2362