### PR TITLE
[AC-2366] fix: move target if styled-components is affected by external manipulation

### DIFF
--- a/src/components/ProviderContainer.tsx
+++ b/src/components/ProviderContainer.tsx
@@ -1,17 +1,18 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { ThemeProvider } from 'styled-components';
+import { StyleSheetManager, ThemeProvider } from 'styled-components';
 
 import SendbirdProvider from '@uikit/lib/Sendbird';
 
 import { ChatAiWidgetProps } from './ChatAiWidget';
 import { generateCSSVariables } from '../colors';
 import {
-  useConstantState,
   ConstantStateProvider,
+  useConstantState,
 } from '../context/ConstantContext';
 import { WidgetOpenProvider } from '../context/WidgetOpenContext';
 import { useChannelStyle } from '../hooks/useChannelStyle';
+import { useStyledComponentsTarget } from '../hooks/useStyledComponentsTarget';
 import useWidgetLocalStorage from '../hooks/useWidgetLocalStorage';
 import { getTheme } from '../theme';
 import { isDashboardPreview } from '../utils';
@@ -65,6 +66,7 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
     }, {});
   }, [accentColor]);
   const { sessionToken, userId } = useWidgetLocalStorage();
+  const target = useStyledComponentsTarget();
 
   if (isFetching) {
     return null;
@@ -81,38 +83,40 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
     //     : restConstantProps.autoOpen ?? autoOpen ?? false
     // }
     >
-      <ThemeProvider theme={styledTheme}>
-        {applicationId && userId && (
-          <SendbirdProvider
-            appId={applicationId}
-            userId={userId}
-            accessToken={sessionToken}
-            nickname={userNickName}
-            customApiHost={apiHost}
-            customWebSocketHost={wsHost}
-            configureSession={configureSession}
-            customExtensionParams={userAgentCustomParams}
-            breakpoint={isMobileView} // A property that determines whether to show it with a layout that fits the mobile screen. Or you can put the width size with `px`.
-            isMentionEnabled={enableMention}
-            theme={theme}
-            colorSet={customColorSet}
-            stringSet={stringSet}
-            uikitOptions={{
-              groupChannel: {
-                input: {
-                  // To hide the file upload icon from the message input
-                  enableDocument: false,
+      <StyleSheetManager target={target}>
+        <ThemeProvider theme={styledTheme}>
+          {applicationId && userId && (
+            <SendbirdProvider
+              appId={applicationId}
+              userId={userId}
+              accessToken={sessionToken}
+              nickname={userNickName}
+              customApiHost={apiHost}
+              customWebSocketHost={wsHost}
+              configureSession={configureSession}
+              customExtensionParams={userAgentCustomParams}
+              breakpoint={isMobileView} // A property that determines whether to show it with a layout that fits the mobile screen. Or you can put the width size with `px`.
+              isMentionEnabled={enableMention}
+              theme={theme}
+              colorSet={customColorSet}
+              stringSet={stringSet}
+              uikitOptions={{
+                groupChannel: {
+                  input: {
+                    // To hide the file upload icon from the message input
+                    enableDocument: false,
+                  },
+                  enableVoiceMessage: false,
+                  enableFeedback: enableEmojiFeedback,
+                  enableSuggestedReplies: true,
                 },
-                enableVoiceMessage: false,
-                enableFeedback: enableEmojiFeedback,
-                enableSuggestedReplies: true,
-              },
-            }}
-          >
-            {children}
-          </SendbirdProvider>
-        )}
-      </ThemeProvider>
+              }}
+            >
+              {children}
+            </SendbirdProvider>
+          )}
+        </ThemeProvider>
+      </StyleSheetManager>
     </WidgetOpenProvider>
   );
 };

--- a/src/hooks/useStyledComponentsTarget.ts
+++ b/src/hooks/useStyledComponentsTarget.ts
@@ -1,0 +1,43 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { version } from 'styled-components/package.json';
+
+function isSCTarget(node: Node): node is HTMLStyleElement {
+  return (
+    node instanceof HTMLStyleElement &&
+    node.getAttribute('data-styled-version') === version
+  );
+}
+
+/**
+ * This hook observes mutations in the document's head
+ * When styled-components, which has already been initialized, is re-added to the head, for example `document.head.innerHTML += ''`, the styles may not render correctly.
+ * Therefore, the target is moved to the body tag.
+ *
+ * This is a short-term solution, and in the long run, we plan to remove styled-components altogether.
+ * */
+export function useStyledComponentsTarget() {
+  const scInitialized = useRef(false);
+  const [target, setTarget] = useState(document.head);
+
+  useLayoutEffect(() => {
+    const observer = new MutationObserver((mutations) => {
+      const mutation = mutations.find(
+        (it) => it.target === document.head && it.addedNodes.length > 0
+      );
+
+      for (const node of mutation?.addedNodes ?? []) {
+        if (!isSCTarget(node)) continue;
+
+        if (scInitialized.current) {
+          setTarget(document.body);
+        } else {
+          scInitialized.current = true;
+        }
+      }
+    });
+    observer.observe(document.head, { childList: true });
+    return () => observer.disconnect();
+  }, []);
+
+  return target;
+}


### PR DESCRIPTION
When directly manipulating the head tag as shown below, there is an issue where styled-components lose their context. In the event that initialized styled-components are re-added, they are considered as directly manipulated into the head tag, prompting the target node to be moved to the body.

```ts
document.head.innerHTML += '';
```

ticket: https://sendbird.atlassian.net/browse/AC-2366
history: https://sendbird.slack.com/archives/C06TL3TJGF8/p1715934439470889