### PR TITLE
[AC-2365] feat: remove channel style autoOpen

### DIFF
--- a/src/components/ChatAiWidget.tsx
+++ b/src/components/ChatAiWidget.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import { StringSet } from '@uikit/ui/Label/stringSet';
+
 import Chat from './Chat';
 import ProviderContainer from './ProviderContainer';
 import WidgetToggleButton from './WidgetToggleButton';
@@ -49,10 +51,12 @@ const MobileComponent = () => {
   );
 };
 
-export interface ChatAiWidgetProps extends Partial<Constant> {
+export interface ChatAiWidgetProps
+  extends Omit<Partial<Constant>, 'stringSet'> {
   applicationId: string;
   botId: string;
   hashedKey?: string;
+  stringSet?: Partial<StringSet>;
 }
 
 export default function ChatAiWidget(props: ChatAiWidgetProps) {

--- a/src/components/WidgetToggleButton.tsx
+++ b/src/components/WidgetToggleButton.tsx
@@ -127,10 +127,10 @@ export default function WidgetToggleButton() {
   };
 
   useEffect(() => {
-    if (autoOpen || botStyle.autoOpen) {
+    if (autoOpen) {
       timer.current = setTimeout(() => setIsOpen(true), 100);
     }
-  }, [botStyle.autoOpen, autoOpen]);
+  }, [autoOpen]);
 
   const toggleButtonProps = {
     onClick: buttonClickHandler,

--- a/src/const.ts
+++ b/src/const.ts
@@ -261,16 +261,6 @@ export const LOCAL_MESSAGE_CUSTOM_TYPE = {
   confirmation: 'confirmation',
 };
 
-export interface BackGroundContent {
-  Component: React.FC;
-  height: string;
-}
-
-export interface StringPageLogoContent {
-  Component: React.FC;
-  width: string;
-}
-
 export interface ChatBottomContent {
   text: string;
   backgroundColor?: string;

--- a/src/context/WidgetSettingContext.tsx
+++ b/src/context/WidgetSettingContext.tsx
@@ -29,6 +29,7 @@ interface BotStyle {
   theme: 'light' | 'dark';
   accentColor: string;
   botMessageBGColor: string;
+  /** @deprecated We no longer use the autoOpen value from the dashboard. **/
   autoOpen: boolean;
 }
 

--- a/src/hooks/useWidgetButtonActivityTimeout.ts
+++ b/src/hooks/useWidgetButtonActivityTimeout.ts
@@ -3,7 +3,6 @@ import { useEffect, useRef } from 'react';
 import useSendbirdStateContext from '@uikit/hooks/useSendbirdStateContext';
 
 import { useConstantState } from '../context/ConstantContext';
-import { useWidgetSetting } from '../context/WidgetSettingContext';
 
 const WS_IDLE_TIMEOUT = 1000 * 60 * 3;
 
@@ -13,7 +12,6 @@ const WS_IDLE_TIMEOUT = 1000 * 60 * 3;
  */
 function useWidgetButtonActivityTimeout() {
   const { autoOpen } = useConstantState();
-  const { botStyle } = useWidgetSetting();
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const store = useSendbirdStateContext();
   const { sdk, initialized } = store.stores.sdkStore;
@@ -38,10 +36,8 @@ function useWidgetButtonActivityTimeout() {
       return;
     }
 
-    const autoOpenValue = autoOpen ?? botStyle.autoOpen;
-
     // We only need to run this logic when autoOpen is disabled
-    if (autoOpenValue) {
+    if (autoOpen) {
       button.removeEventListener('click', handleClick);
       clearTimer();
     } else {
@@ -55,7 +51,7 @@ function useWidgetButtonActivityTimeout() {
       button.removeEventListener('click', handleClick);
       clearTimer();
     };
-  }, [sdk, initialized, botStyle.autoOpen, autoOpen]);
+  }, [sdk, initialized, autoOpen]);
 }
 
 export default useWidgetButtonActivityTimeout;

--- a/src/libs/api/widgetSetting.ts
+++ b/src/libs/api/widgetSetting.ts
@@ -7,6 +7,7 @@ type APIResponse = {
       accent_color: string;
       bot_message_color: string;
     };
+    /** @deprecated We no longer use the autoOpen value from the dashboard. **/
     auto_open: boolean;
   };
   user?: {
@@ -31,6 +32,7 @@ type Response = {
     theme: 'light' | 'dark';
     accentColor: string;
     botMessageBGColor: string;
+    /** @deprecated We no longer use the autoOpen value from the dashboard. **/
     autoOpen: boolean;
   };
   user?: {
@@ -70,7 +72,11 @@ export async function getWidgetSetting({
       theme: json.bot_style.color.theme,
       accentColor: json.bot_style.color.accent_color,
       botMessageBGColor: json.bot_style.color.bot_message_color,
-      autoOpen: json.bot_style.auto_open,
+      /**
+       * NOTE: autoOpen can no longer be configured from the dashboard, so customers will no longer be able to disable autoOpen.
+       *  Therefore, set it to false and remove it so that it is not used.
+       * */
+      autoOpen: false, //json.bot_style.auto_open,
     },
     user: json.user
       ? {


### PR DESCRIPTION
* When the bot studio is deployed, autoOpen can no longer be configured from the dashboard, so customers will no longer be able to disable autoOpen. Therefore, set it to false and remove it so that it is not used. (The widget must be deployed after BotStudio is deployed.)

* ticket: [AC-2365]

[AC-2365]: https://sendbird.atlassian.net/browse/AC-2365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ