### PR TITLE
chore: Added .yarnrc.yml file to root in order to generate node_modules file when install

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
- Added .yarnrc.yml file to root in order to generate node_modules file when install

node_modules is needed for yarn dev to work. without it [default node linker will not generate node modules](https://yarnpkg.com/configuration/yarnrc#nodeLinker).