### PR TITLE
feat: Added onWidgetExpandStateChange

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,8 @@ const App = (props: Props) => {
       // widgetOpenState={false}
       // onWidgetOpenStateChange={(props) => {
       //   console.log('## onChatOpenStateChange: ', props);
+      // onWidgetExpandStateChange={(newIsExpanded) => {
+      //   console.log('## newIsExpanded: ', newIsExpanded);
       // }}
     />
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,9 +43,13 @@ const App = (props: Props) => {
       autoOpen={props.autoOpen}
       renderWidgetToggleButton={props.renderWidgetToggleButton}
       serviceName={props.serviceName}
-      callbacks={props.callbacks}
       deviceType={props.deviceType}
       enableResetHistoryOnConnect={props.enableResetHistoryOnConnect}
+      // callbacks={{
+      //   onWidgetExpandStateChange: (newIsExpanded) => {
+      //     console.log('## newIsExpanded: ', newIsExpanded);
+      //   },
+      // }}
       // botStudioEditProps={{
       //   botInfo: {
       //     profileUrl: 'url',
@@ -75,9 +79,6 @@ const App = (props: Props) => {
       // widgetOpenState={false}
       // onWidgetOpenStateChange={(props) => {
       //   console.log('## onChatOpenStateChange: ', props);
-      // onWidgetExpandStateChange={(newIsExpanded) => {
-      //   console.log('## newIsExpanded: ', newIsExpanded);
-      // }}
     />
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,6 @@ const App = (props: Props) => {
       chatBottomContent={props.chatBottomContent}
       messageBottomContent={props.messageBottomContent}
       replacementTextList={props.replacementTextList}
-      instantConnect={props.instantConnect}
       customRefreshComponent={props.customRefreshComponent}
       configureSession={props.configureSession}
       stringSet={props.stringSet}

--- a/src/components/WidgetWindow.tsx
+++ b/src/components/WidgetWindow.tsx
@@ -100,13 +100,13 @@ const StyledCloseButton = styled.button`
 const WidgetWindow = ({ children }: { children: React.ReactNode }) => {
   const { isOpen, setIsOpen } = useWidgetOpen();
   const [isExpanded, setIsExpanded] = useState(false);
-  const { customUserAgentParam, onWidgetExpandStateChange } =
+  const { customUserAgentParam, callbacks } =
     useConstantState();
 
   const onExpandButtonToggle = () => {
     setIsExpanded((prev) => {
       const newIsExpanded = !prev;
-      onWidgetExpandStateChange?.(newIsExpanded);
+      callbacks?.onWidgetExpandStateChange?.(newIsExpanded);
       return newIsExpanded;
     });
   };

--- a/src/components/WidgetWindow.tsx
+++ b/src/components/WidgetWindow.tsx
@@ -104,8 +104,11 @@ const WidgetWindow = ({ children }: { children: React.ReactNode }) => {
     useConstantState();
 
   const onExpandButtonToggle = () => {
-    onWidgetExpandStateChange?.(!isExpanded);
-    setIsExpanded((prev) => !prev);
+    setIsExpanded((prev) => {
+      const newIsExpanded = !prev;
+      onWidgetExpandStateChange?.(newIsExpanded);
+      return newIsExpanded;
+    });
   };
 
   return (

--- a/src/components/WidgetWindow.tsx
+++ b/src/components/WidgetWindow.tsx
@@ -100,7 +100,13 @@ const StyledCloseButton = styled.button`
 const WidgetWindow = ({ children }: { children: React.ReactNode }) => {
   const { isOpen, setIsOpen } = useWidgetOpen();
   const [isExpanded, setIsExpanded] = useState(false);
-  const { customUserAgentParam } = useConstantState();
+  const { customUserAgentParam, onWidgetExpandStateChange } =
+    useConstantState();
+
+  const onExpandButtonToggle = () => {
+    onWidgetExpandStateChange?.(!isExpanded);
+    setIsExpanded((prev) => !prev);
+  };
 
   return (
     <StyledWidgetWindowWrapper
@@ -109,7 +115,7 @@ const WidgetWindow = ({ children }: { children: React.ReactNode }) => {
       id={elementIds.widgetWindow}
     >
       {isDashboardPreview(customUserAgentParam) && (
-        <StyledExpandButton onClick={() => setIsExpanded((prev) => !prev)}>
+        <StyledExpandButton onClick={onExpandButtonToggle}>
           {isExpanded ? (
             <CollapseIcon id={elementIds.collapseIcon} />
           ) : (

--- a/src/const.ts
+++ b/src/const.ts
@@ -230,6 +230,7 @@ export interface Constant extends Required<ConstantProps> {
    * @private Callback to be called when the widget open state changes.
    */
   onWidgetOpenStateChange?: (params: OnWidgetOpenStateChangeParams) => void;
+  onWidgetExpandStateChange?: (isExpanded: boolean) => void;
 }
 
 export interface ConstantProps {

--- a/src/const.ts
+++ b/src/const.ts
@@ -230,6 +230,9 @@ export interface Constant extends Required<ConstantProps> {
    * @private Callback to be called when the widget open state changes.
    */
   onWidgetOpenStateChange?: (params: OnWidgetOpenStateChangeParams) => void;
+  /**
+   * @private Callback to be called when the widget expand state changes.
+   */
   onWidgetExpandStateChange?: (isExpanded: boolean) => void;
 }
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -230,10 +230,6 @@ export interface Constant extends Required<ConstantProps> {
    * @private Callback to be called when the widget open state changes.
    */
   onWidgetOpenStateChange?: (params: OnWidgetOpenStateChangeParams) => void;
-  /**
-   * @private Callback to be called when the widget expand state changes.
-   */
-  onWidgetExpandStateChange?: (isExpanded: boolean) => void;
 }
 
 export interface ConstantProps {

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useContext, useMemo } from 'react';
+import { createContext, PropsWithChildren, useContext } from 'react';
 
 import { LabelStringSet } from '@uikit/ui/Label';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 export interface SendbirdChatAICallbacks {
   onViewDetailClick?: (data: FunctionCallData) => void;
+  /**
+   * @private Callback to be called when the widget expand state changes.
+   */
+  onWidgetExpandStateChange?: (isExpanded: boolean) => void;
 }
 
 export interface FunctionCallRequestInfo {


### PR DESCRIPTION
Requested by dashoard to add `onWidgetExpandStateChange`

### Why they need?
- “expand / collapse 를 그대로 면 대시보드 상에서 디자인이 깨지는데 이 때 상태 맞춰서 css 오버라이드를 해줘야 하는 경우도 있어서입니다“
Their style breaks when expanded state changes. So they need callback so they can change their css accordingly.

### Changelog
- Added `onWidgetExpandStateChange` to `Constant`

