### PR TITLE
feat: added carousel buttons

### DIFF
--- a/src/components/CustomChannelHeader.tsx
+++ b/src/components/CustomChannelHeader.tsx
@@ -20,7 +20,7 @@ const Root = styled.div`
   align-items: center;
   font-style: normal;
   border: none;
-  border-bottom: 1px solid ${({ theme }) => theme.bgColor.channelHeaderBorder};
+  border-bottom: 1px solid ${({ theme }) => theme.borderColor.channelHeader};
   padding: 11px 12px;
 `;
 

--- a/src/components/MessageDataContent.tsx
+++ b/src/components/MessageDataContent.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { useConstantState } from '../context/ConstantContext';
-import ChevronRightIcon from '../icons/icon-chevron-right.svg';
+import ChevronRightIcon from '../icons/chevron-right.svg';
 import EllipsisIcon from '../icons/icon-ellipsis.svg';
 import MessageBubbleIcon from '../icons/icon-message-bubble.svg';
 import { FunctionCallData } from '../types';

--- a/src/components/WidgetWindow.tsx
+++ b/src/components/WidgetWindow.tsx
@@ -100,8 +100,7 @@ const StyledCloseButton = styled.button`
 const WidgetWindow = ({ children }: { children: React.ReactNode }) => {
   const { isOpen, setIsOpen } = useWidgetOpen();
   const [isExpanded, setIsExpanded] = useState(false);
-  const { customUserAgentParam, callbacks } =
-    useConstantState();
+  const { customUserAgentParam, callbacks } = useConstantState();
 
   const onExpandButtonToggle = () => {
     setIsExpanded((prev) => {

--- a/src/components/messages/ShopItemsMessage.tsx
+++ b/src/components/messages/ShopItemsMessage.tsx
@@ -26,8 +26,6 @@ const Container = styled.div({
   width: '100%',
 });
 
-const IMAGE_HEIGHT = 134;
-
 const ItemText = styled.div`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -42,7 +40,7 @@ const ItemText = styled.div`
 const Image = styled.img`
   flex-shrink: 0;
   width: 100%;
-  height: ${IMAGE_HEIGHT}px;
+  height: 134px;
   object-fit: cover;
   user-select: none;
   -webkit-user-select: none;
@@ -58,7 +56,7 @@ const Button = styled.button<{ direction: 'left' | 'right' }>(
     justifyContent: 'center',
     alignItems: 'center',
     position: 'absolute',
-    top: IMAGE_HEIGHT, // "50%",
+    top: '50%',
     transform: 'translateY(-50%)',
     border: 'none',
     cursor: 'pointer',

--- a/src/components/messages/ShopItemsMessage.tsx
+++ b/src/components/messages/ShopItemsMessage.tsx
@@ -49,7 +49,7 @@ const Image = styled.img`
   -moz-user-select: none;
   -ms-user-select: none;
   -webkit-user-drag: none;
-  backgroundcolor: ${({ theme }) => theme.bgColor.carouselItem};
+  background-color: ${({ theme }) => theme.bgColor.carouselItem};
 `;
 
 const Button = styled.button<{ direction: 'left' | 'right' }>(
@@ -68,6 +68,9 @@ const Button = styled.button<{ direction: 'left' | 'right' }>(
     backgroundColor: theme.bgColor.carouselButton,
     boxShadow:
       '0px 8px 10px 1px rgba(13, 13, 13, 0.12), 0px 3px 14px 2px rgba(13, 13, 13, 0.08), 0px 3px 5px -3px rgba(13, 13, 13, 0.04)',
+    '&:hover': {
+      backgroundColor: theme.bgColor.hover.carouselButton,
+    },
   })
 );
 

--- a/src/components/messages/ShopItemsMessage.tsx
+++ b/src/components/messages/ShopItemsMessage.tsx
@@ -1,8 +1,10 @@
 import { UserMessage } from '@sendbird/chat/message';
 import { ReactNode } from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
-// import { useConstantState } from '../../context/ConstantContext';
+import { useConstantState } from '../../context/ConstantContext';
+import ChevronLeft from '../../icons/chevron-left.svg';
+import ChevronRight from '../../icons/chevron-right.svg';
 import { openURL } from '../../utils';
 import { messageExtension } from '../../utils/messageExtension';
 import { SnapCarousel } from '../ui/SnapCarousel';
@@ -23,7 +25,10 @@ const Container = styled.div({
   gap: 4,
   width: '100%',
 });
-const Text = styled.div`
+
+const IMAGE_HEIGHT = 134;
+
+const ItemText = styled.div`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   display: -webkit-box;
@@ -31,27 +36,40 @@ const Text = styled.div`
   word-break: break-word;
   font-size: 14px;
   font-weight: 400;
-  color: var(--sendbird-light-onlight-01);
+  color: ${({ theme }) => theme.textColor.carouselItem};
 `;
 
 const Image = styled.img`
   flex-shrink: 0;
   width: 100%;
-  height: 134px;
+  height: ${IMAGE_HEIGHT}px;
   object-fit: cover;
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   -webkit-user-drag: none;
+  backgroundcolor: ${({ theme }) => theme.bgColor.carouselItem};
 `;
-const Button = styled.button({
-  position: 'absolute',
-  top: '50%',
-  transform: 'translateY(-50%)',
-  height: 50,
-  width: 50,
-});
+
+const Button = styled.button<{ direction: 'left' | 'right' }>(
+  ({ theme, direction }) => ({
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'absolute',
+    top: IMAGE_HEIGHT, // "50%",
+    transform: 'translateY(-50%)',
+    border: 'none',
+    cursor: 'pointer',
+    borderRadius:
+      direction === 'right' ? '100px 0px 0px 100px' : '0px 100px 100px 0px',
+    padding: direction === 'right' ? '8px 8px 8px 12px' : '8px 12px 8px 8px',
+    backgroundColor: theme.bgColor.carouselButton,
+    boxShadow:
+      '0px 8px 10px 1px rgba(13, 13, 13, 0.12), 0px 3px 14px 2px rgba(13, 13, 13, 0.08), 0px 3px 5px -3px rgba(13, 13, 13, 0.04)',
+  })
+);
 
 type Props = {
   message: UserMessage;
@@ -63,11 +81,13 @@ export const ShopItemsMessage = ({
   textBody,
   streamingBody,
 }: Props) => {
-  // const { isMobileView } = useConstantState();
+  const theme = useTheme();
+  const { isMobileView } = useConstantState();
+
   const items = messageExtension.commerceShopItems.getValidItems(message);
   const isStreaming = messageExtension.isStreaming(message);
   const shouldRenderCarouselBody = isStreaming || items.length > 0;
-  const shouldRenderButtons = false; // !isMobileView && items.length >= 2;
+  const shouldRenderButtons = !isMobileView && items.length >= 2;
   const renderCarouselBody = () => {
     if (isStreaming) return streamingBody;
 
@@ -81,13 +101,29 @@ export const ShopItemsMessage = ({
           shouldRenderButtons && (
             <>
               {activeIndex !== 0 && (
-                <Button style={{ left: -leftMargin }} onClick={onClickPrev}>
-                  {'left'}
+                <Button
+                  style={{ left: -leftMargin }}
+                  onClick={onClickPrev}
+                  direction={'left'}
+                >
+                  <ChevronLeft
+                    width={24}
+                    height={24}
+                    fill={theme.bgColor.carouselButtonIcon}
+                  />
                 </Button>
               )}
               {activeIndex !== items.length - 1 && (
-                <Button style={{ right: -listPadding }} onClick={onClickNext}>
-                  {'right'}
+                <Button
+                  style={{ right: -listPadding }}
+                  onClick={onClickNext}
+                  direction={'right'}
+                >
+                  <ChevronRight
+                    width={24}
+                    height={24}
+                    fill={theme.bgColor.carouselButtonIcon}
+                  />
                 </Button>
               )}
             </>
@@ -102,8 +138,13 @@ export const ShopItemsMessage = ({
             onClick={() => openURL(item.url)}
           >
             <Image src={item.featured_image} alt={item.title} />
-            <div style={{ padding: 12 }}>
-              <Text>{item.title}</Text>
+            <div
+              style={{
+                padding: 12,
+                backgroundColor: theme.bgColor.carouselItem,
+              }}
+            >
+              <ItemText>{item.title}</ItemText>
             </div>
           </SnapCarousel.Item>
         ))}

--- a/src/components/ui/SnapCarousel/index.tsx
+++ b/src/components/ui/SnapCarousel/index.tsx
@@ -26,18 +26,20 @@ const Container = styled.div({
   },
 });
 
-const ItemContainer = styled.div({
-  display: 'flex',
-  flexShrink: 0,
-  scrollSnapAlign: 'start',
-  flexDirection: 'column',
-  borderRadius: 16,
-  overflow: 'hidden',
-  border: '1px solid var(--sendbird-light-onlight-04)',
-  backgroundColor: '#fff',
-  boxSizing: 'border-box',
-  cursor: 'pointer',
-});
+const ItemContainer = styled.div<{ focused: boolean }>(
+  ({ theme, focused }) => ({
+    display: 'flex',
+    flexShrink: 0,
+    scrollSnapAlign: 'start',
+    flexDirection: 'column',
+    borderRadius: 16,
+    overflow: 'hidden',
+    border: `1px solid ${theme.borderColor.carouselItem}`,
+    backgroundColor: theme.bgColor.carouselItem,
+    boxSizing: 'border-box',
+    cursor: focused ? 'pointer' : 'auto',
+  })
+);
 
 type SnapCarouselProps = {
   width?: number | string;
@@ -139,9 +141,11 @@ SnapCarousel.Item = function Item({
   index = 0,
 }: SnapCarouselItemProps) {
   const { activeIndex } = useContext(Context);
+  const focused = index === activeIndex;
   return (
     <ItemContainer
-      onClick={() => index === activeIndex && onClick?.()}
+      focused={focused}
+      onClick={() => focused && onClick?.()}
       role={'button'}
       style={{ width, height }}
     >

--- a/src/icons/chevron-left.svg
+++ b/src/icons/chevron-left.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="#000" xmlns="http://www.w3.org/2000/svg">
+<g id="chevron-left">
+<path id="Fill" fill-rule="evenodd" clip-rule="evenodd" d="M14.293 5.29297L15.7073 6.70718L10.4144 12.0001L15.7073 17.293L14.293 18.7072L7.58594 12.0001L14.293 5.29297Z" fill="current"/>
+</g>
+</svg>

--- a/src/icons/chevron-right.svg
+++ b/src/icons/chevron-right.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="#6210CC" xmlns="http://www.w3.org/2000/svg">
+<g id="chevron-right">
+<path id="Fill" fill-rule="evenodd" clip-rule="evenodd" d="M6.47137 3.52881L5.52856 4.47162L9.05716 8.00021L5.52856 11.5288L6.47137 12.4716L10.9428 8.00021L6.47137 3.52881Z" fill="current"/>
+</g>
+</svg>

--- a/src/icons/icon-chevron-right.svg
+++ b/src/icons/icon-chevron-right.svg
@@ -1,5 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="Icon / Control / ic- / icon-01">
-<path id="Fill" fill-rule="evenodd" clip-rule="evenodd" d="M6.47137 3.52881L5.52856 4.47162L9.05716 8.00021L5.52856 11.5288L6.47137 12.4716L10.9428 8.00021L6.47137 3.52881Z" fill="#6210CC"/>
-</g>
-</svg>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -12,6 +12,7 @@ export interface CommonTheme {
       incomingMessage: string;
       outgoingMessage: string;
       suggestedReply: string;
+      carouselButton: string;
     };
     carouselItem: string;
     carouselButton: string;
@@ -68,6 +69,7 @@ export function getTheme({
             ? generateColorVariants(accentColor)[400]
             : 'var(--sendbird-light-primary-400)',
           suggestedReply: 'var(--sendbird-light-background-100)',
+          carouselButton: 'var(--sendbird-light-background-100)',
         },
         carouselItem: 'var(--sendbird-light-background-50)',
         carouselButton: 'var(--sendbird-light-background-50)',
@@ -116,6 +118,7 @@ export function getTheme({
             ? generateColorVariants(accentColor)[400]
             : 'var(--sendbird-dark-primary-300)',
           suggestedReply: 'var(--sendbird-dark-background-500)',
+          carouselButton: 'var(--sendbird-dark-background-500)',
         },
         carouselItem: 'var(--sendbird-dark-background-500)',
         carouselButton: 'var(--sendbird-dark-background-400)',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -8,12 +8,14 @@ export interface CommonTheme {
     suggestedReply: string;
     bottomBanner: string;
     loadingScreen: string;
-    channelHeaderBorder: string;
     hover: {
       incomingMessage: string;
       outgoingMessage: string;
       suggestedReply: string;
     };
+    carouselItem: string;
+    carouselButton: string;
+    carouselButtonIcon: string;
   };
   textColor: {
     incomingMessage: string;
@@ -26,6 +28,11 @@ export interface CommonTheme {
       poweredBy: string;
       logo: string;
     };
+    carouselItem: string;
+  };
+  borderColor: {
+    channelHeader: string;
+    carouselItem: string;
   };
   accentColor: string;
 }
@@ -52,7 +59,6 @@ export function getTheme({
         suggestedReply: 'var(--sendbird-light-background-50)',
         bottomBanner: 'var(--sendbird-light-background-50)',
         loadingScreen: 'var(--sendbird-light-background-50)',
-        channelHeaderBorder: 'var(--sendbird-light-onlight-04)',
         hover: {
           // Give 1 level darker color for hover
           incomingMessage: botMessageBGColor
@@ -63,6 +69,9 @@ export function getTheme({
             : 'var(--sendbird-light-primary-400)',
           suggestedReply: 'var(--sendbird-light-background-100)',
         },
+        carouselItem: 'var(--sendbird-light-background-50)',
+        carouselButton: 'var(--sendbird-light-background-50)',
+        carouselButtonIcon: 'var(--sendbird-light-background-400)',
       },
       textColor: {
         incomingMessage: botMessageBGColor
@@ -79,6 +88,11 @@ export function getTheme({
           poweredBy: '#5E5E5E',
           logo: '#0D0D0D',
         },
+        carouselItem: 'var(--sendbird-light-onlight-01)',
+      },
+      borderColor: {
+        channelHeader: 'var(--sendbird-light-onlight-04)',
+        carouselItem: 'var(--sendbird-light-onlight-04)',
       },
       accentColor: accentColor ?? 'var(--sendbird-light-primary-300)',
     },
@@ -92,7 +106,6 @@ export function getTheme({
         suggestedReply: 'var(--sendbird-dark-background-600)',
         bottomBanner: 'var(--sendbird-dark-background-600)',
         loadingScreen: 'var(--sendbird-dark-background-600)',
-        channelHeaderBorder: 'var(--sendbird-dark-ondark-04)',
         hover: {
           // Give 1 level lighter color for hover
           incomingMessage: botMessageBGColor
@@ -104,6 +117,9 @@ export function getTheme({
             : 'var(--sendbird-dark-primary-300)',
           suggestedReply: 'var(--sendbird-dark-background-500)',
         },
+        carouselItem: 'var(--sendbird-dark-background-500)',
+        carouselButton: 'var(--sendbird-dark-background-400)',
+        carouselButtonIcon: 'var(--sendbird-dark-background-50)',
       },
       textColor: {
         outgoingMessage: accentColor
@@ -120,6 +136,11 @@ export function getTheme({
           poweredBy: 'var(--sendbird-dark-background-200)',
           logo: 'var(--sendbird-dark-background-50)',
         },
+        carouselItem: 'var(--sendbird-dark-ondark-01)',
+      },
+      borderColor: {
+        channelHeader: 'var(--sendbird-dark-ondark-04)',
+        carouselItem: 'var(--sendbird-dark-ondark-04)',
       },
       accentColor: accentColor ?? 'var(--sendbird-dark-primary-200)',
     },


### PR DESCRIPTION
## screenshot
|start|center|end|
|-|-|-|
|<img width="457" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/ec2e8fb4-b1c7-4d9b-b5ab-c1a529210e2d">|<img width="457" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/7b4e092d-ec67-4c90-80f2-7c9fc3909ed8">|<img width="457" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/03c0b485-665e-4658-9837-8f418c34643e">|

## dark mode
<img width="300" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/391c08a9-9b2c-4a25-861d-547ba92d0d5d">


figma: https://www.figma.com/design/b8Rs7CKH3RcbzlKSji3b2u/%5BFeature%5D-202405_Shopify-bot?node-id=12459-76434&t=Bw2WTWrfWOXbCnCZ-4