### PR TITLE
refactor: configureSession as params

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,6 @@ const App = (props: Props) => {
     <ChatAiWidget
       applicationId={props.applicationId}
       botId={props.botId}
-      userId={props.userId}
       userNickName={props.userNickName}
       betaMark={props.betaMark}
       customBetaMarkText={props.customBetaMarkText}
@@ -33,6 +32,7 @@ const App = (props: Props) => {
       messageBottomContent={props.messageBottomContent}
       replacementTextList={props.replacementTextList}
       customRefreshComponent={props.customRefreshComponent}
+      userId={props.userId}
       configureSession={props.configureSession}
       stringSet={props.stringSet}
       enableSourceMessage={props.enableSourceMessage}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -41,7 +41,7 @@ const Chat = () => {
     stores.sdkStore.initialized,
   ]);
 
-  if (!widgetSession.channelUrl) return <></>;
+
 
   const onBeforeSendMessage = <
     T extends UserMessageCreateParams | FileMessageCreateParams
@@ -60,7 +60,7 @@ const Chat = () => {
 
   return (
     <GroupChannelProvider
-      channelUrl={widgetSession.channelUrl}
+      channelUrl={widgetSession.channelUrl ?? ''}
       scrollBehavior={'smooth'}
       onBeforeSendUserMessage={onBeforeSendMessage}
       onBeforeSendFileMessage={onBeforeSendMessage}


### PR DESCRIPTION
In chat SDK, because of the instance check in SessionHandler,
customer cannot use SessionHandler when using self-service or umd builds.

Therefore, we are refactoring it to also handle it as a general object.

example
```ts
const chatbotConfigs = {};

chatbotConfigs.userId = 'USER_ID';
chatbotConfigs.configureSession = () => ({
    onSessionTokenRequired: (resolve, reject) => {
      issueSessionToken('USER_ID')
        .then(token => resolve(token));
        .catch(err => reject(err));
    },
    onSessionRefreshed: () => {
      // Handle session refresh
    },
    onSessionError: (err) => {
      // Handle session error
    },
    onSessionClosed: () => {
      // Handle session closure
    };
})
```