### PR TITLE
chore: Display expand button only when callbacks.onWidgetExpandStateChange is given

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,13 +71,14 @@ const App = (props: Props) => {
       //   ],
       //   styles: {
       //     theme: 'light',
-      //     primaryColor: 'orange',
+      //     accentColor: 'orange',
       //     botMessageBGColor: 'hotpink',
       //   },
       // }}
-      // widgetOpenState={false}
+      // widgetOpenState={true}
       // onWidgetOpenStateChange={(props) => {
       //   console.log('## onChatOpenStateChange: ', props);
+      // }}
     />
   );
 };

--- a/src/components/CustomChannelHeader.tsx
+++ b/src/components/CustomChannelHeader.tsx
@@ -9,7 +9,7 @@ import { elementIds } from '../const';
 import { useConstantState } from '../context/ConstantContext';
 import { useWidgetOpen } from '../context/WidgetOpenContext';
 import CloseButton from '../icons/ic-widget-close.svg';
-import { isDashboardPreview, isEmpty } from '../utils';
+import { isEmpty } from '../utils';
 
 const RIGHT_WITH_EXPAND_BUTTON = 60; // gap = 6 and button width = 24 => 24 * 2 + 6 * 2 = 60
 const RIGHT_WITHOUT_EXPAND_BUTTON = 26;
@@ -78,7 +78,7 @@ export default function CustomChannelHeader({
     customBetaMarkText,
     customRefreshComponent,
     isMobileView,
-    customUserAgentParam,
+    callbacks,
   } = useConstantState();
   const { setIsOpen } = useWidgetOpen();
 
@@ -131,7 +131,7 @@ export default function CustomChannelHeader({
                     right: isMobileView
                       ? 0
                       : // to make the refresh icon appear next to the close icon in the widget window
-                      isDashboardPreview(customUserAgentParam)
+                      callbacks?.onWidgetExpandStateChange
                       ? RIGHT_WITH_EXPAND_BUTTON
                       : RIGHT_WITHOUT_EXPAND_BUTTON,
                   }

--- a/src/components/WidgetWindow.tsx
+++ b/src/components/WidgetWindow.tsx
@@ -7,7 +7,6 @@ import { useWidgetOpen } from '../context/WidgetOpenContext';
 import CloseIcon from '../icons/ic-widget-close.svg';
 import CollapseIcon from '../icons/icon-collapse.svg';
 import ExpandIcon from '../icons/icon-expand.svg';
-import { isDashboardPreview } from '../utils';
 
 const StyledWidgetWindowWrapper = styled.div<{
   isOpen: boolean;
@@ -100,7 +99,7 @@ const StyledCloseButton = styled.button`
 const WidgetWindow = ({ children }: { children: React.ReactNode }) => {
   const { isOpen, setIsOpen } = useWidgetOpen();
   const [isExpanded, setIsExpanded] = useState(false);
-  const { customUserAgentParam, callbacks } = useConstantState();
+  const { callbacks } = useConstantState();
 
   const onExpandButtonToggle = () => {
     setIsExpanded((prev) => {
@@ -116,7 +115,7 @@ const WidgetWindow = ({ children }: { children: React.ReactNode }) => {
       isExpanded={isExpanded}
       id={elementIds.widgetWindow}
     >
-      {isDashboardPreview(customUserAgentParam) && (
+      {callbacks?.onWidgetExpandStateChange && (
         <StyledExpandButton onClick={onExpandButtonToggle}>
           {isExpanded ? (
             <CollapseIcon id={elementIds.collapseIcon} />


### PR DESCRIPTION
We changed spec:
https://sendbird.slack.com/archives/C0585965FFA/p1716431041224409?thread_ts=1716430648.689039&cid=C0585965FFA