### PR TITLE
release/v1.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.5.11] (May 23 2024)
+### Feat:
+- Mssage input is now being disabled upon sending a message until a reply message is received from the bot and finished streaming
+
+### Chore:
+- Expand button is now being displayed only when `callbacks.onWidgetExpandStateChange` is given
+
+### Deprecated:
+- `autoOpen` in `BotStyle` has been deprecated and is no longer being considered internally due to its use-case removal
+
 ## [1.5.10] (May 23 2024)
 ### Fix:
 - Fixed a bug where the widget was not working when `configureSession` was set.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -15,7 +15,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "1.5.10",
+    "@sendbird/chat-ai-widget": "1.5.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,19 +3022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.5.10":
-  version: 1.5.10
-  resolution: "@sendbird/chat-ai-widget@npm:1.5.10"
-  dependencies:
-    styled-components: "npm:^5.3.11"
-  peerDependencies:
-    react: ^16.8.6 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/3533bd9da1d7b79e80ce0ff2b15b31eebfb9ef70f7dbcf9a83a020fc16a783c4294ceb1ef462fbb1ecbcbff7dc5df6cc1c7976715dd07a3646f71f721596d4df
-  languageName: node
-  linkType: hard
-
-"@sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.5.11, @sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:
@@ -15441,7 +15429,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "self-service@workspace:packages/self-service"
   dependencies:
-    "@sendbird/chat-ai-widget": "npm:1.5.10"
+    "@sendbird/chat-ai-widget": "npm:1.5.11"
     "@types/react": "npm:^18.0.37"
     "@types/react-dom": "npm:^18.0.11"
     "@vitejs/plugin-react": "npm:^4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,7 +3022,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.5.10, @sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.5.10":
+  version: 1.5.10
+  resolution: "@sendbird/chat-ai-widget@npm:1.5.10"
+  dependencies:
+    styled-components: "npm:^5.3.11"
+  peerDependencies:
+    react: ^16.8.6 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/3533bd9da1d7b79e80ce0ff2b15b31eebfb9ef70f7dbcf9a83a020fc16a783c4294ceb1ef462fbb1ecbcbff7dc5df6cc1c7976715dd07a3646f71f721596d4df
+  languageName: node
+  linkType: hard
+
+"@sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:


### PR DESCRIPTION
## [1.5.11] (May 23 2024)
### Feat:
- Mssage input is now being disabled upon sending a message until a reply message is received from the bot and finished streaming

### Chore:
- Expand button is now being displayed only when `callbacks.onWidgetExpandStateChange` is given

### Deprecated:
- `autoOpen` in `BotStyle` has been deprecated and is no longer being considered internally due to its use-case removal
