### PR TITLE
chore: Display MessageDataContent for last message only

### DIFF
--- a/src/components/CustomChannelComponent.tsx
+++ b/src/components/CustomChannelComponent.tsx
@@ -334,9 +334,11 @@ export function CustomChannelComponent() {
                     }
                     return null;
                   })()}
-                {isDashboardPreview(customUserAgentParam) && message.data && (
-                  <MessageDataContent messageData={message.data} />
-                )}
+                {message.messageId === lastMessage?.messageId &&
+                  isDashboardPreview(customUserAgentParam) &&
+                  message.data && (
+                    <MessageDataContent messageData={message.data} />
+                  )}
               </div>
             </Message>
           );


### PR DESCRIPTION
### Changelog
- `MessageDataContent` is now being displayed for last message only


Ticket: https://sendbird.atlassian.net/browse/AC-2466