### PR TITLE
release/v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [1.6.0] (May 31, 2024)
+### Feat:
+- Added `messageInputControls` to `Constant`. It allows to control enabled/disabled state of the message input
+- Added `dateLocale` to `Constant`. It is applied to string values of message timestamp and date separator
+- Added the `enableHideWidgetForDeactivatedUser` to `Constant`. It is used to decide whether the chatbot widget is hidden or not when the user is deactivated
+```tsx
+import { ar } from 'date-fns/locale';
+
+<ChatAiWidget
+  applicationId={props.applicationId}
+  botId={props.botId}
+  messageInputControls={{
+    blockWhileBotResponding: 30000, // Change force unblock timeout to 30 seconds. Default value is 10 seconds.
+  }}
+  dateLocale={ar} // Applies Arabic locale.
+  enableHideWidgetForDeactivatedUser={true}
+/>
+```
+Refer to [**Available props** section in **README.md**](./README.md#available-props) file for details.
+
+### Fix:
+- Fixed a bug where multiple timestamps of messages are not grouped into one when should be if `botStudioEditProps.welcomeMessages` is given
+
 ## [1.5.12] (May 28, 2024)
 ### Feat:
 - Added horizontal suggested replies support.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ export default App;
 | `customRefreshComponent` | `{ icon: string, style: React.CSSProperties, width: string, height: string, onClick: () => void }` | No       | N/A           | Customizable refresh component. You can set properties such as `icon`, `style`, `width`, `height`, and `onClick`. |
 | `configureSession`      | `() => SessionHandler`                  | No      | N/A           | Function to configure the user session. The example usage can be found [here](./custom-session-guide.md). <br/><br/> Must be used with `userId`.|
 | `autoOpen`              | `boolean`                               | No       | N/A        | Determines whether the chatbot widget automatically opens when the browser window is opened.                   |
-| `messageInputControls.blockWhileBotResponding` | `boolean \| number` | No | N/A | Allows to control enabled/disabled state of the message input for waiting for the bot's reply mesage. If number value is given, a timer will be set to force unblock the message input. |
 | `enableResetHistoryOnConnect`        | `boolean`  | No       | `false`       | Determines whether the chatbot widget history is reset when the user connects. |
-| `enableHideWidgetForDeactivatedUser` | `boolean`  | No       | `false`       | Determines whether the chatbot widget is hidden when the user is deactivated.  |
+| `messageInputControls.blockWhileBotResponding` | `boolean \| number` | No | N/A | Allows to control enabled/disabled state of the message input for waiting for the bot's reply mesage. If number value is given, a timer will be set to force unblock the message input. |
+| `dateLocale` | `Locale` | No | `enUS` | Locale value to be applied to string values of message timestamp and date separator. Locale values must be imported from `date-fns`.                                                    |
+| `enableHideWidgetForDeactivatedUser` | `boolean`  | No       | `false`       | Determines whether the chatbot widget is hidden when the user is deactivated.                                                                                                           |
 
 ## For internal contributors
 - [Release guide](./release-guide.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.5.12",
+  "version": "1.6.0",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -15,7 +15,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "1.5.12",
+    "@sendbird/chat-ai-widget": "1.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,10 +45,10 @@ const App = (props: Props) => {
       serviceName={props.serviceName}
       deviceType={props.deviceType}
       enableResetHistoryOnConnect={props.enableResetHistoryOnConnect}
-      messageInputControls={{
-        blockWhileBotResponding: false,
-      }}
-      dateLocale={ar}
+      // messageInputControls={{
+      //   blockWhileBotResponding: false,
+      // }}
+      // dateLocale={ar}
       // callbacks={{
       //   onWidgetExpandStateChange: (newIsExpanded) => {
       //     console.log('## newIsExpanded: ', newIsExpanded);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { ar } from 'date-fns/locale';
 import React from 'react';
 
 import { StringSet } from '@uikit/ui/Label/stringSet';
@@ -44,9 +45,10 @@ const App = (props: Props) => {
       serviceName={props.serviceName}
       deviceType={props.deviceType}
       enableResetHistoryOnConnect={props.enableResetHistoryOnConnect}
-      // messageInputControls={{
-      //   blockWhileBotResponding: false,
-      // }}
+      messageInputControls={{
+        blockWhileBotResponding: false,
+      }}
+      dateLocale={ar}
       // callbacks={{
       //   onWidgetExpandStateChange: (newIsExpanded) => {
       //     console.log('## newIsExpanded: ', newIsExpanded);

--- a/src/const.ts
+++ b/src/const.ts
@@ -172,7 +172,7 @@ export interface Constant extends ConstantFeatureFlags {
    */
   autoOpen?: boolean;
   /**
-   * @public locale instance to be applied
+   * @public Locale value to be applied to string values of message timestamp and date separator.
    */
   dateLocale: Locale;
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,7 +3022,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.5.12, @sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.5.12":
+  version: 1.5.12
+  resolution: "@sendbird/chat-ai-widget@npm:1.5.12"
+  dependencies:
+    styled-components: "npm:^5.3.11"
+  peerDependencies:
+    react: ^16.8.6 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/beff02cdedd4d8413c6a1f8683242a131fd59e3a48f2321b330695fe240b40912b9927ed824d8f3dd426a69f71a7a1263a5aa2bec03cea98d979983fee72623f
+  languageName: node
+  linkType: hard
+
+"@sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,19 +3022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.5.12":
-  version: 1.5.12
-  resolution: "@sendbird/chat-ai-widget@npm:1.5.12"
-  dependencies:
-    styled-components: "npm:^5.3.11"
-  peerDependencies:
-    react: ^16.8.6 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/beff02cdedd4d8413c6a1f8683242a131fd59e3a48f2321b330695fe240b40912b9927ed824d8f3dd426a69f71a7a1263a5aa2bec03cea98d979983fee72623f
-  languageName: node
-  linkType: hard
-
-"@sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.6.0, @sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:
@@ -15711,7 +15699,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "self-service@workspace:packages/self-service"
   dependencies:
-    "@sendbird/chat-ai-widget": "npm:1.5.12"
+    "@sendbird/chat-ai-widget": "npm:1.6.0"
     "@types/react": "npm:^18.0.37"
     "@types/react-dom": "npm:^18.0.11"
     "@vitejs/plugin-react": "npm:^4.2.1"


### PR DESCRIPTION
## [1.6.0] (May 31, 2024)
### Feat:
- Added `messageInputControls` to `Constant`. It allows to control enabled/disabled state of the message input
- Added `dateLocale` to `Constant`. It is applied to string values of message timestamp and date separator
- Added the `enableHideWidgetForDeactivatedUser` to `Constant`. It is used to decide whether the chatbot widget is hidden or not when the user is deactivated
```tsx
import { ar } from 'date-fns/locale';

<ChatAiWidget
  applicationId={props.applicationId}
  botId={props.botId}
  messageInputControls={{
    blockWhileBotResponding: 30000, // Change force unblock timeout to 30 seconds. Default value is 10 seconds.
  }}
  dateLocale={ar} // Applies Arabic locale.
  enableHideWidgetForDeactivatedUser={true}
/>
```
Refer to [**Available props** section in **README.md**](./README.md#available-props) file for details.

### Fix:
- Fixed a bug where multiple timestamps of messages are not grouped into one when should be if `botStudioEditProps.welcomeMessages` is given
