### PR TITLE
feat: Added video message support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { ar } from 'date-fns/locale';
 import React from 'react';
 
 import { StringSet } from '@uikit/ui/Label/stringSet';

--- a/src/components/ChatAiWidget.tsx
+++ b/src/components/ChatAiWidget.tsx
@@ -47,7 +47,7 @@ const MobileComponent = () => {
   return (
     <>
       <MobileContainer
-        style={{ display: (isOpen && isVisible) ? 'block' : 'none' }}
+        style={{ display: isOpen && isVisible ? 'block' : 'none' }}
         width={mobileContainerWidth}
         id={elementIds.widgetWindow}
       >

--- a/src/components/CustomMessage.tsx
+++ b/src/components/CustomMessage.tsx
@@ -136,6 +136,7 @@ export default function CustomMessage(props: Props) {
     if (message.isFileMessage()) {
       return (
         <BotMessageWithBodyInput
+          wideContainer
           {...commonProps}
           botUser={botUser}
           bodyComponent={<FileMessage message={message} />}

--- a/src/components/CustomMessage.tsx
+++ b/src/components/CustomMessage.tsx
@@ -1,7 +1,7 @@
 import { User } from '@sendbird/chat';
 
 import TypingDots from '@uikit/ui/TypingIndicatorBubble/TypingDots';
-import { CoreMessageType } from '@uikit/utils';
+import { CoreMessageType, isVideoMessage } from '@uikit/utils';
 
 import AdminMessage from './AdminMessage';
 import BotMessageFeedback from './BotMessageFeedback';
@@ -136,7 +136,7 @@ export default function CustomMessage(props: Props) {
     if (message.isFileMessage()) {
       return (
         <BotMessageWithBodyInput
-          wideContainer
+          wideContainer={isVideoMessage(message)}
           {...commonProps}
           botUser={botUser}
           bodyComponent={<FileMessage message={message} />}

--- a/src/components/FileMessage.tsx
+++ b/src/components/FileMessage.tsx
@@ -44,9 +44,14 @@ export default function FileMessage(props: Props) {
         )}
         */}
       {isVideoMessage(message) && (
-        // eslint-disable-next-line jsx-a11y/media-has-caption
         <video controls className="sendbird-ai-widget-file-message">
           <source src={message.url} type={message.type} />
+          <track
+            kind="captions"
+            src="path/to/your-captions.vtt"
+            srcLang="en"
+            label="English"
+          />
         </video>
       )}
       {isImageMessage(message) && (

--- a/src/components/FileMessage.tsx
+++ b/src/components/FileMessage.tsx
@@ -2,7 +2,7 @@ import '../css/index.css';
 import { FileMessage as ChatFileMessage } from '@sendbird/chat/message';
 
 import { useGroupChannelContext } from '@uikit/modules/GroupChannel/context/GroupChannelProvider';
-import { isVideoMessage } from '@uikit/utils';
+import {isImageMessage, isVideoMessage} from '@uikit/utils';
 // import { FileViewerComponent } from '@sendbird/uikit-react/ui/FileViewer';
 // import {downloadFileWithUrl, noop} from '../utils';
 // import {createPortal} from 'react-dom';
@@ -43,12 +43,13 @@ export default function FileMessage(props: Props) {
           root!
         )}
         */}
-      {isVideoMessage(message) ? (
+      {isVideoMessage(message) && (
         // eslint-disable-next-line jsx-a11y/media-has-caption
         <video controls className="sendbird-ai-widget-file-message">
           <source src={message.url} type={message.type} />
         </video>
-      ) : (
+      )}
+      {isImageMessage(message) && (
         <img
           className="sendbird-ai-widget-file-message"
           src={message.url}

--- a/src/components/FileMessage.tsx
+++ b/src/components/FileMessage.tsx
@@ -46,7 +46,7 @@ export default function FileMessage(props: Props) {
       {isVideoMessage(message) && (
         <video controls className="sendbird-ai-widget-file-message">
           <source src={message.url} type={message.type} />
-          <track kind="captions" srcLang="en" label="English" />
+          <track kind="captions" />
         </video>
       )}
       {isImageMessage(message) && (

--- a/src/components/FileMessage.tsx
+++ b/src/components/FileMessage.tsx
@@ -1,7 +1,9 @@
 import '../css/index.css';
 import { FileMessage as ChatFileMessage } from '@sendbird/chat/message';
+import { match } from 'ts-pattern';
 
 import { useGroupChannelContext } from '@uikit/modules/GroupChannel/context/GroupChannelProvider';
+import { isVideoMessage } from '@uikit/utils';
 // import { FileViewerComponent } from '@sendbird/uikit-react/ui/FileViewer';
 // import {downloadFileWithUrl, noop} from '../utils';
 // import {createPortal} from 'react-dom';
@@ -38,14 +40,23 @@ export default function FileMessage(props: Props) {
           root!
         )}
         */}
-      <img
-        className="sendbird-ai-widget-file-message-image"
-        src={message.url}
-        alt={''}
-        onLoad={() => {
-          scrollToBottom();
-        }}
-      />
+      {match(message)
+        .when(isVideoMessage, () => (
+          // eslint-disable-next-line jsx-a11y/media-has-caption
+          <video controls className="sendbird-ai-widget-file-message">
+            <source src={message.url} type={message.type} />
+          </video>
+        ))
+        .otherwise(() => (
+          <img
+            className="sendbird-ai-widget-file-message"
+            src={message.url}
+            alt={''}
+            onLoad={() => {
+              scrollToBottom();
+            }}
+          />
+        ))}
     </div>
   );
 }

--- a/src/components/FileMessage.tsx
+++ b/src/components/FileMessage.tsx
@@ -46,12 +46,7 @@ export default function FileMessage(props: Props) {
       {isVideoMessage(message) && (
         <video controls className="sendbird-ai-widget-file-message">
           <source src={message.url} type={message.type} />
-          <track
-            kind="captions"
-            src="path/to/your-captions.vtt"
-            srcLang="en"
-            label="English"
-          />
+          <track kind="captions" srcLang="en" label="English" />
         </video>
       )}
       {isImageMessage(message) && (

--- a/src/components/FileMessage.tsx
+++ b/src/components/FileMessage.tsx
@@ -1,6 +1,5 @@
 import '../css/index.css';
 import { FileMessage as ChatFileMessage } from '@sendbird/chat/message';
-import { match } from 'ts-pattern';
 
 import { useGroupChannelContext } from '@uikit/modules/GroupChannel/context/GroupChannelProvider';
 import { isVideoMessage } from '@uikit/utils';
@@ -18,6 +17,10 @@ export default function FileMessage(props: Props) {
 
   // const root = document.getElementById('aichatbot-widget-window');
 
+  /**
+   * Currently only video and image file messages will be sent.
+   * TODO: In the future, we may support other file types. When we do, we need to update the logic.
+   */
   return (
     <div className="sendbird-ai-widget-file-message-root">
       {/*Please keep the commented code for referencing in the future when adding file viewer*/}
@@ -40,23 +43,21 @@ export default function FileMessage(props: Props) {
           root!
         )}
         */}
-      {match(message)
-        .when(isVideoMessage, () => (
-          // eslint-disable-next-line jsx-a11y/media-has-caption
-          <video controls className="sendbird-ai-widget-file-message">
-            <source src={message.url} type={message.type} />
-          </video>
-        ))
-        .otherwise(() => (
-          <img
-            className="sendbird-ai-widget-file-message"
-            src={message.url}
-            alt={''}
-            onLoad={() => {
-              scrollToBottom();
-            }}
-          />
-        ))}
+      {isVideoMessage(message) ? (
+        // eslint-disable-next-line jsx-a11y/media-has-caption
+        <video controls className="sendbird-ai-widget-file-message">
+          <source src={message.url} type={message.type} />
+        </video>
+      ) : (
+        <img
+          className="sendbird-ai-widget-file-message"
+          src={message.url}
+          alt={''}
+          onLoad={() => {
+            scrollToBottom();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/FileMessage.tsx
+++ b/src/components/FileMessage.tsx
@@ -2,7 +2,7 @@ import '../css/index.css';
 import { FileMessage as ChatFileMessage } from '@sendbird/chat/message';
 
 import { useGroupChannelContext } from '@uikit/modules/GroupChannel/context/GroupChannelProvider';
-import {isImageMessage, isVideoMessage} from '@uikit/utils';
+import { isImageMessage, isVideoMessage } from '@uikit/utils';
 // import { FileViewerComponent } from '@sendbird/uikit-react/ui/FileViewer';
 // import {downloadFileWithUrl, noop} from '../utils';
 // import {createPortal} from 'react-dom';

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -76,7 +76,7 @@ input:focus {
   width: 100%;
 }
 
-.sendbird-ai-widget-file-message-image {
+.sendbird-ai-widget-file-message {
   border-radius: 16px;
   width: 100%;
 }


### PR DESCRIPTION
### Changelog
- Supports video typed file messages when sent by bot user

### Side note
- [Video message takes up 'wide view'.](https://sendbird.slack.com/archives/C0585965FFA/p1717486126855269?thread_ts=1717397963.921489&cid=C0585965FFA)

### Ticket
https://sendbird.atlassian.net/browse/AC-2197

### After

[Video and Audio APIs - Learn web development _ MDN.webm](https://github.com/sendbird/chat-ai-widget/assets/16806397/843c2e49-6496-43df-9979-7bb1eebe41fc)

[Video and Audio APIs - Learn web development _ MDN (1).webm](https://github.com/sendbird/chat-ai-widget/assets/16806397/22602105-18b2-47ee-be90-72c0dce2f8b8)


Note: The testing is when message is sent by me not bot. It is only for testing. In production, only bot message is supported.