### PR TITLE
release: v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.6.2] (Jun 7, 2024)
+### Feat:
+- Added video message support for bot messages. The widget now supports video messages sent by the bot.
+- Added support for using new channels in `widget_setting` when a new channel is created.
+- Added `sessionToken` prop for managing manual sessions.
+
+### Fix:
+- Fixed a bug where the widget would not connect to the bot when the cached channel is not found and now creates a new channel.
+- Fixed a bug where the feedback did not work according to the option set in the dashboard.
+
+### Chore:
+- Removed the default value of `false` for mentions in self-service.
+
 ## [1.6.1] (Jun 4, 2024)
 ### change:
 - Removed auto focusing of message input when disabled state changes to false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -15,7 +15,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "1.6.1",
+    "@sendbird/chat-ai-widget": "1.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,7 +3022,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.6.1, @sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.6.1":
+  version: 1.6.1
+  resolution: "@sendbird/chat-ai-widget@npm:1.6.1"
+  dependencies:
+    styled-components: "npm:^5.3.11"
+  peerDependencies:
+    date-fns: ^3.6.0
+    react: ^16.8.6 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    date-fns:
+      optional: true
+  checksum: 10c0/1c4a35cbc6b0ab6251de19948b0780740bfc1ac809f2ef0c6969ed99586cc326428ca4bd3c7462e2b278a86ae814a3484274f708305c26ca4c37d6b46a2702ea
+  languageName: node
+  linkType: hard
+
+"@sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,23 +3022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.6.1":
-  version: 1.6.1
-  resolution: "@sendbird/chat-ai-widget@npm:1.6.1"
-  dependencies:
-    styled-components: "npm:^5.3.11"
-  peerDependencies:
-    date-fns: ^3.6.0
-    react: ^16.8.6 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    date-fns:
-      optional: true
-  checksum: 10c0/1c4a35cbc6b0ab6251de19948b0780740bfc1ac809f2ef0c6969ed99586cc326428ca4bd3c7462e2b278a86ae814a3484274f708305c26ca4c37d6b46a2702ea
-  languageName: node
-  linkType: hard
-
-"@sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.6.2, @sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:
@@ -15715,7 +15699,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "self-service@workspace:packages/self-service"
   dependencies:
-    "@sendbird/chat-ai-widget": "npm:1.6.1"
+    "@sendbird/chat-ai-widget": "npm:1.6.2"
     "@types/react": "npm:^18.0.37"
     "@types/react-dom": "npm:^18.0.11"
     "@vitejs/plugin-react": "npm:^4.2.1"


### PR DESCRIPTION
## [1.6.2] (Jun 7, 2024)
### Feat:
- Added video message support for bot messages. The widget now supports video messages sent by the bot.
- Added support for using new channels in `widget_setting` when a new channel is created.
- Added `sessionToken` prop for managing manual sessions.

### Fix:
- Fixed a bug where the widget would not connect to the bot when the cached channel is not found and now creates a new channel.
- Fixed a bug where the feedback did not work according to the option set in the dashboard.

### Chore:
- Removed the default value of `false` for mentions in self-service.
