### PR TITLE
[AC-2721] fix: changed url color to inherit

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -83,7 +83,7 @@ input:focus {
 
 .sendbird-word__url {
   font-weight: 700;
-  color: black;
+  color: inherit;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Changes
<img width="394" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/5ddde962-acc7-4ef5-a0e1-09ed77700109">

<img width="383" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/029df4e5-cad2-4c06-ae51-c413ec4b95e2">


ticket: [AC-2721]

[AC-2721]: https://sendbird.atlassian.net/browse/AC-2721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ