### PR TITLE
[AC-2850] fix: changed other user message text color

### DIFF
--- a/src/components/UserMessageWithBodyInput.tsx
+++ b/src/components/UserMessageWithBodyInput.tsx
@@ -30,7 +30,7 @@ interface BodyContainerProps {
 
 const BodyContainer = styled.div<BodyContainerProps>`
   font-size: 14px;
-  color: ${({ theme }) => theme.textColor.outgoingMessage};
+  color: ${({ theme }) => theme.textColor.incomingMessage};
   max-width: calc(100% - 96px);
   font-weight: normal;
   font-stretch: normal;


### PR DESCRIPTION
## Changes
- changed text color of other user message

### AS-IS
<img width="359" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/15580a30-1ca8-4818-96dd-8c3db684f062">

### TO-BE
<img width="358" alt="image" src="https://github.com/sendbird/chat-ai-widget/assets/26326015/c6067552-683d-480a-be31-d4da5e20207c">

ticket: [AC-2850]


[AC-2850]: https://sendbird.atlassian.net/browse/AC-2850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ