### PR TITLE
[AC-2950] feat: window object

### DIFF
--- a/src/components/widget/ProviderContainer.tsx
+++ b/src/components/widget/ProviderContainer.tsx
@@ -19,6 +19,7 @@ import {
   useWidgetState,
   WidgetStateProvider,
 } from '../../context/WidgetStateContext';
+import { useAssignGlobalFunction } from '../../hooks/useAssignGlobalFunction';
 import { useStyledComponentsTarget } from '../../hooks/useStyledComponentsTarget';
 import { getTheme } from '../../theme';
 import { isDashboardPreview } from '../../utils';
@@ -42,6 +43,7 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
     enableHideWidgetForDeactivatedUser,
   } = useConstantState();
 
+  useAssignGlobalFunction();
   const { setIsVisible } = useWidgetState();
   const { botStyle } = useWidgetSetting();
   const session = useWidgetSession();

--- a/src/hooks/useAssignGlobalFunction.ts
+++ b/src/hooks/useAssignGlobalFunction.ts
@@ -1,0 +1,33 @@
+import { useLayoutEffect } from 'react';
+
+import { useConstantState } from '../context/ConstantContext';
+import { useWidgetState } from '../context/WidgetStateContext';
+import { clearWidgetSessionCache } from '../libs/storage/widgetSessionCache';
+
+declare global {
+  interface Window {
+    sbWidget: {
+      open: () => void;
+      close: () => void;
+      clearCache: () => void;
+    };
+  }
+}
+
+/**
+ * The useAssignGlobalFunction hook adds the sendbirdWidget object to the global window object.
+ * The sendbirdWidget object contains open, close, and clearCache methods,
+ * allowing control of the widget state and cache clearing from a non-React environment.
+ */
+export function useAssignGlobalFunction() {
+  const { applicationId: appId, botId } = useConstantState();
+  const { setIsOpen } = useWidgetState();
+
+  useLayoutEffect(() => {
+    window.sbWidget = {
+      open: () => setIsOpen(true),
+      close: () => setIsOpen(false),
+      clearCache: () => clearWidgetSessionCache({ appId, botId }),
+    };
+  });
+}


### PR DESCRIPTION
## Changes
- Added `window.sbWidget` interface to allowing control of the widget state and cache clearing from a non-React environment.

ticket: [AC-2950]

[AC-2950]: https://sendbird.atlassian.net/browse/AC-2950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ