### PR TITLE
[AC-3103] feat: add locale

### DIFF
--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -4,13 +4,16 @@ import useSendbirdStateContext from '@uikit/hooks/useSendbirdStateContext';
 
 import { ChatContainer } from './context/ChatProvider';
 import { ChatUI } from './ui';
+import { useConstantState } from '../../context/ConstantContext';
 import { useWidgetSession, useWidgetSetting } from '../../context/WidgetSettingContext';
+import { useAssignGlobalFunction } from '../../hooks/useAssignGlobalFunction';
 import useAutoDismissMobileKeyboardHandler from '../../hooks/useAutoDismissMobileKeyboardHandler';
 import { useResetHistoryOnConnected } from '../../hooks/useResetHistoryOnConnected';
 import { useWidgetInactivityTimeout } from '../../hooks/useWidgetInactivityTimeout';
 
 const Chat = ({ fullscreen = false }: { fullscreen?: boolean }) => {
   const { stores } = useSendbirdStateContext();
+  const { locale } = useConstantState();
   const widgetSetting = useWidgetSetting();
   const widgetSession = useWidgetSession();
 
@@ -29,6 +32,13 @@ const Chat = ({ fullscreen = false }: { fullscreen?: boolean }) => {
     stores.sdkStore.initialized,
   ]);
 
+  // Set locale for chatbot
+  useEffect(() => {
+    if (locale && stores.sdkStore.initialized && stores.sdkStore.sdk) {
+      stores.sdkStore.sdk.setLocaleForChatbot(locale);
+    }
+  }, [locale, stores.sdkStore.initialized, stores.sdkStore.sdk]);
+
   return (
     <ChatContainer
       sdk={stores.sdkStore.sdk}
@@ -44,6 +54,7 @@ const Chat = ({ fullscreen = false }: { fullscreen?: boolean }) => {
 };
 
 const HeadlessForHooks = ({ fullscreen }: { fullscreen: boolean }) => {
+  useAssignGlobalFunction();
   useResetHistoryOnConnected();
   useWidgetInactivityTimeout(fullscreen);
   useAutoDismissMobileKeyboardHandler();

--- a/src/components/ui/WidgetButton.tsx
+++ b/src/components/ui/WidgetButton.tsx
@@ -104,15 +104,7 @@ const CloseIconWrapper = styled(IconWrapper)<IconWrapperProps>`
 const Icon = {
   Open: (props: { url?: string }) => {
     const { url } = props;
-
-    if (url) {
-      if (url.endsWith('.svg')) {
-        return <img src={url} alt={'widget-toggle-button'} data-svg={true} />;
-      } else {
-        return <img src={url} alt={'widget-toggle-button'} />;
-      }
-    }
-
+    if (url) return <img src={url} alt={'widget-toggle-button'} data-svg={url.endsWith('.svg')} />;
     return <BotOutlinedIcon />;
   },
   Close: () => <ChevronDownIcon />,

--- a/src/components/widget/ProviderContainer.tsx
+++ b/src/components/widget/ProviderContainer.tsx
@@ -1,8 +1,7 @@
 import { SendbirdErrorCode } from '@sendbird/chat';
-import React, { PropsWithChildren, useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { StyleSheetManager, ThemeProvider } from 'styled-components';
 
-import { useSendbirdStateContext } from '@uikit/index';
 import SendbirdProvider from '@uikit/lib/Sendbird';
 
 import { ChatAiWidgetProps } from './ChatAiWidget';
@@ -10,7 +9,6 @@ import { generateCSSVariables } from '../../colors';
 import { ConstantStateProvider, useConstantState } from '../../context/ConstantContext';
 import { useWidgetSession, useWidgetSetting, WidgetSettingProvider } from '../../context/WidgetSettingContext';
 import { useWidgetState, WidgetStateProvider } from '../../context/WidgetStateContext';
-import { useAssignGlobalFunction } from '../../hooks/useAssignGlobalFunction';
 import { useStyledComponentsTarget } from '../../hooks/useStyledComponentsTarget';
 import { getTheme } from '../../theme';
 import { isDashboardPreview } from '../../utils';
@@ -136,25 +134,9 @@ export default function ProviderContainer(props: ProviderContainerProps) {
     <ConstantStateProvider {...props}>
       <WidgetSettingProvider>
         <WidgetStateProvider>
-          <SBComponent>
-            <HeadlessComponent>{props.children}</HeadlessComponent>
-          </SBComponent>
+          <SBComponent>{props.children}</SBComponent>
         </WidgetStateProvider>
       </WidgetSettingProvider>
     </ConstantStateProvider>
   );
 }
-
-const HeadlessComponent = ({ children }: PropsWithChildren) => {
-  useAssignGlobalFunction();
-  const { locale } = useConstantState();
-  const { stores } = useSendbirdStateContext();
-
-  useEffect(() => {
-    if (locale && stores.sdkStore.initialized && stores.sdkStore.sdk) {
-      stores.sdkStore.sdk.setLocaleForChatbot(locale);
-    }
-  }, [locale, stores.sdkStore.initialized, stores.sdkStore.sdk]);
-
-  return <>{children}</>;
-};

--- a/src/components/widget/ProviderContainer.tsx
+++ b/src/components/widget/ProviderContainer.tsx
@@ -1,7 +1,8 @@
 import { SendbirdErrorCode } from '@sendbird/chat';
-import React, { useMemo } from 'react';
+import React, { PropsWithChildren, useEffect, useMemo } from 'react';
 import { StyleSheetManager, ThemeProvider } from 'styled-components';
 
+import { useSendbirdStateContext } from '@uikit/index';
 import SendbirdProvider from '@uikit/lib/Sendbird';
 
 import { ChatAiWidgetProps } from './ChatAiWidget';
@@ -33,7 +34,6 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
     enableHideWidgetForDeactivatedUser,
   } = useConstantState();
 
-  useAssignGlobalFunction();
   const { setIsVisible } = useWidgetState();
   const { botStyle } = useWidgetSetting();
   const session = useWidgetSession();
@@ -136,9 +136,25 @@ export default function ProviderContainer(props: ProviderContainerProps) {
     <ConstantStateProvider {...props}>
       <WidgetSettingProvider>
         <WidgetStateProvider>
-          <SBComponent>{props.children}</SBComponent>
+          <SBComponent>
+            <HeadlessComponent>{props.children}</HeadlessComponent>
+          </SBComponent>
         </WidgetStateProvider>
       </WidgetSettingProvider>
     </ConstantStateProvider>
   );
 }
+
+const HeadlessComponent = ({ children }: PropsWithChildren) => {
+  useAssignGlobalFunction();
+  const { locale } = useConstantState();
+  const { stores } = useSendbirdStateContext();
+
+  useEffect(() => {
+    if (locale && stores.sdkStore.initialized && stores.sdkStore.sdk) {
+      stores.sdkStore.sdk.setLocaleForChatbot(locale);
+    }
+  }, [locale, stores.sdkStore.initialized, stores.sdkStore.sdk]);
+
+  return <>{children}</>;
+};

--- a/src/const.ts
+++ b/src/const.ts
@@ -166,6 +166,11 @@ export interface Constant extends ConstantFeatureFlags {
   autoOpen?: boolean;
   /**
    * @public
+   * @description Sets the locale for the chatbot.
+   */
+  locale?: string;
+  /**
+   * @public
    * @description Locale value to be applied to string values of message timestamp and date separator.
    */
   dateLocale: Locale;
@@ -322,7 +327,6 @@ export const elementIds = {
   expandIcon: 'aichatbot-widget-expand-icon',
   closeIcon: 'aichatbot-widget-close-icon',
   refreshIcon: 'aichatbot-widget-refresh-icon',
-  uikitModal: 'sendbird-modal-root',
 };
 
 export const widgetServiceName = {

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -80,6 +80,7 @@ export const ConstantStateProvider = (props: PropsWithChildren<ConstantContextPr
           ...initialState.messageInputControls,
           ...props.messageInputControls,
         },
+        locale: props.locale,
         dateLocale: props.dateLocale ?? initialState.dateLocale,
         // ----- Feature flag props ----- //
         autoOpen: props.autoOpen,

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -80,7 +80,7 @@ export const ConstantStateProvider = (props: PropsWithChildren<ConstantContextPr
           ...initialState.messageInputControls,
           ...props.messageInputControls,
         },
-        locale: props.locale,
+        locale: props.locale ?? navigator.language,
         dateLocale: props.dateLocale ?? initialState.dateLocale,
         // ----- Feature flag props ----- //
         autoOpen: props.autoOpen,

--- a/src/context/WidgetSettingContext.tsx
+++ b/src/context/WidgetSettingContext.tsx
@@ -47,6 +47,7 @@ export const WidgetSettingProvider = ({ children }: React.PropsWithChildren) => 
     botStudioEditProps,
     autoOpen,
     callbacks,
+    locale,
   } = useConstantState();
 
   if (!appId || !botId) {
@@ -91,6 +92,7 @@ export const WidgetSettingProvider = ({ children }: React.PropsWithChildren) => 
       appId,
       botId,
       userId: strategy === 'manual' ? injectedUserId : cachedSession?.userId,
+      locale,
     })
       .onError(callbacks?.onWidgetSettingFailure)
       .onGetBotStyle((style) => setBotStyle(style))

--- a/src/libs/api/widgetSetting.ts
+++ b/src/libs/api/widgetSetting.ts
@@ -30,6 +30,7 @@ type Params = {
   createChannel?: boolean;
   userId?: string;
   // sessionToken?: string;
+  locale?: string;
 };
 
 type Response = {
@@ -59,12 +60,14 @@ export async function getWidgetSetting({
   createUserAndChannel,
   createChannel,
   userId,
+  locale,
 }: Params): Promise<Response> {
   // const headers = sessionToken ? { 'Session-Key': sessionToken } : undefined;
   const params = asQueryParams({
     create_user_and_channel: asBoolString(createUserAndChannel),
     create_channel: asBoolString(createChannel),
     user_id: userId,
+    locale,
   });
   const path = resolvePath(host, `/v3/bots/${botId}/${appId}/widget_setting?${params}`);
 
@@ -221,7 +224,7 @@ function getParamsByStrategy(
     if (useCachedSession) {
       return { userId: params.userId };
     } else {
-      return { createUserAndChannel: true };
+      return { createUserAndChannel: true, locale: params.locale };
     }
   } else {
     if (useCachedSession) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,12 +7,13 @@ const WidgetApp = () => {
   const urlParams = new URLSearchParams(window.location.search);
   const appId = urlParams.get('app_id') ?? import.meta.env.VITE_CHAT_WIDGET_APP_ID;
   const botId = urlParams.get('bot_id') ?? import.meta.env.VITE_CHAT_WIDGET_BOT_ID;
+  const locale = urlParams.get('locale') ?? undefined;
 
   if (!appId || !botId) {
     return null;
   }
 
-  return <App applicationId={appId} botId={botId} />;
+  return <App applicationId={appId} botId={botId} locale={locale} />;
 };
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(


### PR DESCRIPTION
## Changes

- Add `locale` to the constant state and configurations. (The `locale` will be used in sending multi-language messages.)
- Use `navigator.language` as the default locale

ticket: [AC-3103], [AC-3448]

- [x] Update Chat SDK

[AC-3103]: https://sendbird.atlassian.net/browse/AC-3103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AC-3448]: https://sendbird.atlassian.net/browse/AC-3448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ