### PR TITLE
release/v1.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.7.8] (Aug 16, 2024)
+### Fix:
+- Fixed a bug where session not being reset on unauthorized error during channel fetch
+- Fixed a bug where browser cached messages are not being cleared on refreshing the channel
+
+### Chore:
+- Added `enableWidgetExpandButton` in `Constant`. Refer to [**Available props** section in **README.md**](./README.md#available-props) file for details
+- `WidgetWindowFullScreen` no longer disconnects when widget is closed
+- Texts in user message that start with `tel:`, `mailto:`, or `sms:` are now being considered as url
+
 ## [1.7.7] (Aug 7, 2024)
 ### Fix:
 - Added a root element to the full-screen component for the modal to avoid crashes when clicking feedback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Chore:
 - Added `enableWidgetExpandButton` in `Constant`. Refer to [**Available props** section in **README.md**](./README.md#available-props) file for details
-- `WidgetWindowFullScreen` no longer disconnects when widget is closed
+- `WidgetWindowFullScreen` no longer disconnects while network is connected
 - Texts in user message that start with `tel:`, `mailto:`, or `sms:` are now being considered as url
 
 ## [1.7.7] (Aug 7, 2024)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -14,7 +14,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "1.7.7",
+    "@sendbird/chat-ai-widget": "1.7.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,23 +3022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.7.7":
-  version: 1.7.7
-  resolution: "@sendbird/chat-ai-widget@npm:1.7.7"
-  dependencies:
-    styled-components: "npm:^5.3.11"
-  peerDependencies:
-    date-fns: ^3.6.0
-    react: ^16.8.6 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    date-fns:
-      optional: true
-  checksum: 10c0/17c22f8c0ebc51323821ca6f4bf3befc6cc5f3fa5c23dd6f7d791a2f9403639bc4000eb3f547047382e7a9e659a9f093aaaa07d541af5939fbc925bb539fc11f
-  languageName: node
-  linkType: hard
-
-"@sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.7.8, @sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:
@@ -15588,7 +15572,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "self-service@workspace:packages/self-service"
   dependencies:
-    "@sendbird/chat-ai-widget": "npm:1.7.7"
+    "@sendbird/chat-ai-widget": "npm:1.7.8"
     "@types/react": "npm:^18.0.37"
     "@types/react-dom": "npm:^18.0.11"
     "@vitejs/plugin-react": "npm:^4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,7 +3022,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.7.7, @sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.7.7":
+  version: 1.7.7
+  resolution: "@sendbird/chat-ai-widget@npm:1.7.7"
+  dependencies:
+    styled-components: "npm:^5.3.11"
+  peerDependencies:
+    date-fns: ^3.6.0
+    react: ^16.8.6 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    date-fns:
+      optional: true
+  checksum: 10c0/17c22f8c0ebc51323821ca6f4bf3befc6cc5f3fa5c23dd6f7d791a2f9403639bc4000eb3f547047382e7a9e659a9f093aaaa07d541af5939fbc925bb539fc11f
+  languageName: node
+  linkType: hard
+
+"@sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:


### PR DESCRIPTION
## Changelog
## [1.7.8] (Aug 16, 2024)
### Fix:
- Fixed a bug where session not being reset on unauthorized error during channel fetch
- Fixed a bug where browser cached messages are not being cleared on refreshing the channel

### Chore:
- Added `enableWidgetExpandButton` in `Constant`. Refer to [**Available props** section in **README.md**](./README.md#available-props) file for details
- `WidgetWindowFullScreen` no longer disconnects when widget is closed
- Texts in user message that start with `tel:`, `mailto:`, or `sms:` are now being considered as url
