### PR TITLE
release: v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+## [1.8.2] (Sep 19, 2024)
+### Fix:
+- Removed CSS styles that could potentially affect the client's website
+
 ## [1.8.1] (Sep 12, 2024)
 ### Fix:
 - Fixed that prevent zoom when focusing on input in iOS mobile
 
 ## [1.8.0] (Sep 12, 2024)
-
 ### Feat:
 - **File Message Support**: File attachment in messages is now supported. Of course, drag-and-drop and copy-paste actions are also supported.
 - **Locale Support**: Added a `locale` option to support multiple languages for welcome messages and suggested replies. If not specified, the browser's default language will be used. (support for multilingual settings will be available in the dashboard). 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -14,7 +14,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "1.8.1",
+    "@sendbird/chat-ai-widget": "1.8.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,7 +3259,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.8.1, @sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.8.1":
+  version: 1.8.1
+  resolution: "@sendbird/chat-ai-widget@npm:1.8.1"
+  dependencies:
+    styled-components: "npm:^5.3.11"
+  peerDependencies:
+    date-fns: ^3.6.0
+    react: ^16.8.6 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    date-fns:
+      optional: true
+  checksum: 10c0/41949dca0399ef835c9e40547ae751079282340039da8bdd49706d56cdb3f2e5516161fec2094681a74c2f3a5b37cc690372a6c3a2fe7e5c2b18beebb8b2fc8b
+  languageName: node
+  linkType: hard
+
+"@sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,23 +3259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.8.1":
-  version: 1.8.1
-  resolution: "@sendbird/chat-ai-widget@npm:1.8.1"
-  dependencies:
-    styled-components: "npm:^5.3.11"
-  peerDependencies:
-    date-fns: ^3.6.0
-    react: ^16.8.6 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    date-fns:
-      optional: true
-  checksum: 10c0/41949dca0399ef835c9e40547ae751079282340039da8bdd49706d56cdb3f2e5516161fec2094681a74c2f3a5b37cc690372a6c3a2fe7e5c2b18beebb8b2fc8b
-  languageName: node
-  linkType: hard
-
-"@sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.8.2, @sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:
@@ -15972,7 +15956,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "self-service@workspace:packages/self-service"
   dependencies:
-    "@sendbird/chat-ai-widget": "npm:1.8.1"
+    "@sendbird/chat-ai-widget": "npm:1.8.2"
     "@types/react": "npm:^18.0.37"
     "@types/react-dom": "npm:^18.0.11"
     "@vitejs/plugin-react": "npm:^4.2.1"


### PR DESCRIPTION
## [1.8.2] (Sep 19, 2024)
### Fix:
- Removed CSS styles that could potentially affect the client's website
