### PR TITLE
chore: release v1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.8.3] (Oct 10, 2024)
+### Feat:
+- Added stack direction to message list and set as bottom
+- Added pending & failed icon to sent messages
+
+### Chore:
+- Added service name to playground
+- Added utm source to banner link
+
 ## [1.8.2] (Sep 19, 2024)
 ### Fix:
 - Removed CSS styles that could potentially affect the client's website

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -14,7 +14,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "1.8.2",
+    "@sendbird/chat-ai-widget": "1.8.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,7 +3259,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.8.2, @sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.8.2":
+  version: 1.8.2
+  resolution: "@sendbird/chat-ai-widget@npm:1.8.2"
+  dependencies:
+    styled-components: "npm:^5.3.11"
+  peerDependencies:
+    date-fns: ^3.6.0
+    react: ^16.8.6 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    date-fns:
+      optional: true
+  checksum: 10c0/f1104777e9938293730b030a820b6e26207ce9db554a7b400a451bee451c3fc41ae4f8bc7440503237a75a70bb2e9094a96b9e8f2d0dc597900d7d722a87cbcc
+  languageName: node
+  linkType: hard
+
+"@sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,23 +3259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.8.2":
-  version: 1.8.2
-  resolution: "@sendbird/chat-ai-widget@npm:1.8.2"
-  dependencies:
-    styled-components: "npm:^5.3.11"
-  peerDependencies:
-    date-fns: ^3.6.0
-    react: ^16.8.6 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    date-fns:
-      optional: true
-  checksum: 10c0/f1104777e9938293730b030a820b6e26207ce9db554a7b400a451bee451c3fc41ae4f8bc7440503237a75a70bb2e9094a96b9e8f2d0dc597900d7d722a87cbcc
-  languageName: node
-  linkType: hard
-
-"@sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.8.3, @sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:
@@ -15972,7 +15956,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "self-service@workspace:packages/self-service"
   dependencies:
-    "@sendbird/chat-ai-widget": "npm:1.8.2"
+    "@sendbird/chat-ai-widget": "npm:1.8.3"
     "@types/react": "npm:^18.0.37"
     "@types/react-dom": "npm:^18.0.11"
     "@vitejs/plugin-react": "npm:^4.2.1"


### PR DESCRIPTION
## [1.8.3] (Oct 10, 2024)
### Feat:
- Added stack direction to message list and set as bottom
- Added pending & failed icon to sent messages

### Chore:
- Added service name to playground
- Added utm source to banner link