### PR TITLE
chore: release v1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.8.4] (Oct 22, 2024)
+### Fix:
+- Passed missing locale to DateSeparator component
+
 ## [1.8.3] (Oct 10, 2024)
 ### Feat:
 - Added stack direction to message list and set as bottom

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sendbird/chat-ai-widget",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Sendbird Chat AI Widget,\n Detailed documentation can be found at https://github.com/sendbird/chat-ai-widget#readme",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",

--- a/packages/self-service/package.json
+++ b/packages/self-service/package.json
@@ -14,7 +14,7 @@
     "format": "npm run prettier:fix && npm run lint:fix"
   },
   "dependencies": {
-    "@sendbird/chat-ai-widget": "1.8.3",
+    "@sendbird/chat-ai-widget": "1.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,7 +3259,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.8.3, @sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.8.3":
+  version: 1.8.3
+  resolution: "@sendbird/chat-ai-widget@npm:1.8.3"
+  dependencies:
+    styled-components: "npm:^5.3.11"
+  peerDependencies:
+    date-fns: ^3.6.0
+    react: ^16.8.6 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    date-fns:
+      optional: true
+  checksum: 10c0/445f0f182eb3d133d6bcd660780da5fbfd32ba89a68086a63f751674f0990851b3c5af7820bc1d64a6e4fa0226e9ddc837707c358559e492e6bbc0123ede1422
+  languageName: node
+  linkType: hard
+
+"@sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,23 +3259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sendbird/chat-ai-widget@npm:1.8.3":
-  version: 1.8.3
-  resolution: "@sendbird/chat-ai-widget@npm:1.8.3"
-  dependencies:
-    styled-components: "npm:^5.3.11"
-  peerDependencies:
-    date-fns: ^3.6.0
-    react: ^16.8.6 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    date-fns:
-      optional: true
-  checksum: 10c0/445f0f182eb3d133d6bcd660780da5fbfd32ba89a68086a63f751674f0990851b3c5af7820bc1d64a6e4fa0226e9ddc837707c358559e492e6bbc0123ede1422
-  languageName: node
-  linkType: hard
-
-"@sendbird/chat-ai-widget@workspace:.":
+"@sendbird/chat-ai-widget@npm:1.8.4, @sendbird/chat-ai-widget@workspace:.":
   version: 0.0.0-use.local
   resolution: "@sendbird/chat-ai-widget@workspace:."
   dependencies:
@@ -15972,7 +15956,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "self-service@workspace:packages/self-service"
   dependencies:
-    "@sendbird/chat-ai-widget": "npm:1.8.3"
+    "@sendbird/chat-ai-widget": "npm:1.8.4"
     "@types/react": "npm:^18.0.37"
     "@types/react-dom": "npm:^18.0.11"
     "@vitejs/plugin-react": "npm:^4.2.1"


### PR DESCRIPTION
## [1.8.4] (Oct 22, 2024)
### Fix:
- Passed missing locale to DateSeparator component
