### PR TITLE
fix: conflicts with uikit

### DIFF
--- a/src/components/widget/ProviderContainer.tsx
+++ b/src/components/widget/ProviderContainer.tsx
@@ -31,6 +31,7 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
     isMobileView,
     dateLocale,
     enableHideWidgetForDeactivatedUser,
+    localCacheEnabled,
   } = useConstantState();
 
   const { setIsVisible } = useWidgetState();
@@ -80,6 +81,7 @@ const SBComponent = ({ children }: { children: React.ReactElement }) => {
             nickname={userNickName}
             customApiHost={apiHost}
             customWebSocketHost={wsHost}
+            sdkInitParams={{ localCacheEnabled }}
             configureSession={configureSession}
             customExtensionParams={userAgentCustomParams}
             breakpoint={isMobileView} // A property that determines whether to show it with a layout that fits the mobile screen. Or you can put the width size with `px`.

--- a/src/const.ts
+++ b/src/const.ts
@@ -266,6 +266,11 @@ export interface Constant extends ConstantFeatureFlags, ConstantAIFeatures {
    * @description Callback to be called when the widget open state changes.
    */
   onWidgetOpenStateChange?: (params: OnWidgetOpenStateChangeParams) => void;
+  /**
+   * @private
+   * @description Determines whether to use the local cache of the Chat SDK.
+   */
+  localCacheEnabled?: boolean;
 }
 
 interface ConstantAIFeatures {

--- a/src/context/ConstantContext.tsx
+++ b/src/context/ConstantContext.tsx
@@ -76,6 +76,7 @@ export const ConstantStateProvider = (props: PropsWithChildren<ConstantContextPr
         botStudioEditProps: props.botStudioEditProps,
         widgetOpenState: props.widgetOpenState,
         onWidgetOpenStateChange: props.onWidgetOpenStateChange,
+        localCacheEnabled: props.localCacheEnabled,
         messageInputControls: {
           ...initialState.messageInputControls,
           ...props.messageInputControls,


### PR DESCRIPTION
## Changes

- Use `disconnectWebsocket` instead of `disconnect` (applied changes from [PR #1219](https://github.com/sendbird/sendbird-uikit-react/pull/1219))
- Prevent changes to the theme if it has already been added by other logic.
- Added `localCacheEnabled` flag to control the use of local cache in the Chat SDK.

ticket: [AC-4281]

## Additional Notes
- uikit changes: https://github.com/sendbird/sendbird-uikit-react/compare/f8af8706c4b6b429559e085bc60e1c9908f5ac5b...4fc0619472906ca5a0a3a8992650ca8bcfdf54c0

## Checklist
Before requesting a code review, please check the following:
- [x] **[Required]** CI has passed all checks.
- [x] **[Required]** A self-review has been conducted to ensure there are no minor mistakes.
- [x] **[Required]** Unnecessary comments/debugging code have been removed.
- [x] **[Required]** All requirements specified in the ticket have been accurately implemented.
- [x] Ensure the ticket has been updated with the sprint, status, and story points.


[AC-4281]: https://sendbird.atlassian.net/browse/AC-4281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ