### PR TITLE
feat: Create sample for bot reply sources feature

### DIFF
--- a/src/components/BotMessageWithBodyInput.tsx
+++ b/src/components/BotMessageWithBodyInput.tsx
@@ -1,3 +1,4 @@
+import { BaseMessage } from '@sendbird/chat/message';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 
@@ -44,6 +45,7 @@ type Props = {
   chainBottom?: boolean;
   messageFeedback?: ReactNode;
   wideContainer?: boolean;
+  message?: BaseMessage;
 };
 
 // TODO: When changing the layout, it should be modified to apply flexibly.

--- a/src/components/BotReplySourcesPanel.tsx
+++ b/src/components/BotReplySourcesPanel.tsx
@@ -66,6 +66,11 @@ const BotReplySourceContainer = styled.div<BotReplySourceContainerProps>`
   border-top: ${({ hasDelimiter }) => (hasDelimiter ? '1px solid' : undefined)};
 `;
 
+const BotReplySourcesContainer = styled.div`
+  max-height: 120px;
+  overflow-y: scroll;
+`;
+
 function BotReplySource({ source, index }: { source: BotReplySource; index: number }) {
   const { title, url } = source;
   return (
@@ -95,6 +100,26 @@ export default function BotReplySourcesPanel({ message }: BotReplySourcesPanelPr
       title: 'QWER',
       url: 'https://namu.wiki/w/QWER',
     },
+    {
+      title: 'QWER',
+      url: 'https://namu.wiki/w/QWER',
+    },
+    {
+      title: 'QWER',
+      url: 'https://namu.wiki/w/QWER',
+    },
+    {
+      title: 'QWER',
+      url: 'https://namu.wiki/w/QWER',
+    },
+    {
+      title: 'QWER',
+      url: 'https://namu.wiki/w/QWER',
+    },
+    {
+      title: 'QWER',
+      url: 'https://namu.wiki/w/QWER',
+    },
   ];
 
   function openBotReplySourcesPanel() {
@@ -114,23 +139,26 @@ export default function BotReplySourcesPanel({ message }: BotReplySourcesPanelPr
   const widgetWindow = document.getElementById(elementIds.widgetWindow);
 
   return (
-    <>
-      {botReplySources && <BotReplySourcesButton onClick={openBotReplySourcesPanel}>Source Info</BotReplySourcesButton>}
-      {botReplySources &&
-        widgetWindow &&
-        isBotReplySourcePanelVisible &&
-        createPortal(
-          <div>
-            <ShadowBackground onClick={() => setIsBotReplySourcePanelExpanded(false)} />
-            <Root isExpanded={isBotReplySourcePanelExpanded} onTransitionEnd={handleAnimationEnd}>
-              <Title>Bot reply sources</Title>
-              {botReplySources.map((source, i) => (
-                <BotReplySource key={i} source={source} index={i} />
-              ))}
-            </Root>
-          </div>,
-          widgetWindow,
-        )}
-    </>
+    botReplySources && (
+      <>
+        {<BotReplySourcesButton onClick={openBotReplySourcesPanel}>Source Info</BotReplySourcesButton>}
+        {widgetWindow &&
+          isBotReplySourcePanelVisible &&
+          createPortal(
+            <div>
+              <ShadowBackground onClick={() => setIsBotReplySourcePanelExpanded(false)} />
+              <Root isExpanded={isBotReplySourcePanelExpanded} onTransitionEnd={handleAnimationEnd}>
+                <Title>Bot reply sources</Title>
+                <BotReplySourcesContainer>
+                  {botReplySources.map((source, i) => (
+                    <BotReplySource key={i} source={source} index={i} />
+                  ))}
+                </BotReplySourcesContainer>
+              </Root>
+            </div>,
+            widgetWindow,
+          )}
+      </>
+    )
   );
 }

--- a/src/components/BotReplySourcesPanel.tsx
+++ b/src/components/BotReplySourcesPanel.tsx
@@ -1,0 +1,136 @@
+import { BaseMessage } from '@sendbird/chat/message';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import styled from 'styled-components';
+
+import { elementIds } from '../const';
+
+interface BotReplySource {
+  title: string;
+  url: string;
+}
+
+interface BotReplySourcesPanelProps {
+  message: BaseMessage;
+}
+
+interface RootProps {
+  isExpanded: boolean;
+}
+
+interface BotReplySourceContainerProps {
+  hasDelimiter: boolean;
+}
+
+const Title = styled.div`
+  padding: 8px 0 8px;
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+const Root = styled.div<RootProps>`
+  display: flex;
+  position: absolute; // Set the Panel component's position to absolute relative to the aichatbot-widget-window component.
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  box-sizing: border-box;
+  flex-direction: column;
+  padding: 8px 24px 40px;
+  border-radius: 16px 16px 0 0;
+  background-color: ${({ theme }) => theme.bgColor.incomingMessage};
+
+  z-index: 100;
+  transition: transform 0.3s ease-in-out;
+  transform: translateY(${({ isExpanded }) => (isExpanded ? '0%' : '100%')});
+`;
+
+const ShadowBackground = styled.div`
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+const BotReplySourcesButton = styled.button`
+  padding: 4px 8px;
+  margin: 8px 0 0 36px;
+`;
+
+const BotReplySourceContainer = styled.div<BotReplySourceContainerProps>`
+  display: flex;
+  font-size: 14px;
+  padding: 8px 0;
+  border-top: ${({ hasDelimiter }) => (hasDelimiter ? '1px solid' : undefined)};
+`;
+
+function BotReplySource({ source, index }: { source: BotReplySource; index: number }) {
+  const { title, url } = source;
+  return (
+    <BotReplySourceContainer hasDelimiter={index > 0}>
+      <a href={url} target="_blank" rel="noreferrer">
+        {title}
+      </a>
+    </BotReplySourceContainer>
+  );
+}
+
+export default function BotReplySourcesPanel({ message }: BotReplySourcesPanelProps) {
+  const [isBotReplySourcePanelVisible, setIsBotReplySourcePanelVisible] = useState(false);
+  const [isBotReplySourcePanelExpanded, setIsBotReplySourcePanelExpanded] = useState(false);
+
+  let botReplySources: BotReplySource[] = message?.extendedMessagePayload?.['bot_reply_sources'] as BotReplySource[];
+  botReplySources = [
+    {
+      title: 'Sendbird docs',
+      url: 'https://sendbird.com/docs',
+    },
+    {
+      title: 'About cat',
+      url: 'https://www.britannica.com/animal/cat',
+    },
+    {
+      title: 'QWER',
+      url: 'https://namu.wiki/w/QWER',
+    },
+  ];
+
+  function openBotReplySourcesPanel() {
+    setIsBotReplySourcePanelVisible(true);
+  }
+  function handleAnimationEnd() {
+    if (!isBotReplySourcePanelExpanded) {
+      setIsBotReplySourcePanelVisible(false); // Remove panel from DOM after slide-out animation
+    }
+  }
+
+  useEffect(() => {
+    if (isBotReplySourcePanelVisible) {
+      setIsBotReplySourcePanelExpanded(true);
+    }
+  }, [isBotReplySourcePanelVisible]);
+  const widgetWindow = document.getElementById(elementIds.widgetWindow);
+
+  return (
+    <>
+      {botReplySources && <BotReplySourcesButton onClick={openBotReplySourcesPanel}>Source Info</BotReplySourcesButton>}
+      {botReplySources &&
+        widgetWindow &&
+        isBotReplySourcePanelVisible &&
+        createPortal(
+          <div>
+            <ShadowBackground onClick={() => setIsBotReplySourcePanelExpanded(false)} />
+            <Root isExpanded={isBotReplySourcePanelExpanded} onTransitionEnd={handleAnimationEnd}>
+              <Title>Bot reply sources</Title>
+              {botReplySources.map((source, i) => (
+                <BotReplySource key={i} source={source} index={i} />
+              ))}
+            </Root>
+          </div>,
+          widgetWindow,
+        )}
+    </>
+  );
+}

--- a/src/components/chat/ui/ChatMessageList.tsx
+++ b/src/components/chat/ui/ChatMessageList.tsx
@@ -86,6 +86,8 @@ export const ChatMessageList = () => {
                     <MessageDataContent messageData={message.data} />
                   )}
 
+                {<BotReplySourcesPanel message={message} />}
+
                 {showRepliesOnLastMessage && suggestedReplies.length > 0 && (
                   <SuggestedRepliesContainer
                     replies={suggestedReplies}
@@ -95,8 +97,6 @@ export const ChatMessageList = () => {
                     }}
                   />
                 )}
-
-                {<BotReplySourcesPanel message={message} />}
               </div>
             </div>
           );

--- a/src/components/chat/ui/ChatMessageList.tsx
+++ b/src/components/chat/ui/ChatMessageList.tsx
@@ -11,6 +11,7 @@ import { Placeholder } from '../../../foundation/components/Placeholder';
 import { ScrollToBottomButton } from '../../../foundation/components/ScrollToBottomButton';
 import { isDashboardPreview } from '../../../utils';
 import { getMessageGrouping } from '../../../utils/messages';
+import BotReplySourcesPanel from '../../BotReplySourcesPanel';
 import CustomMessage from '../../CustomMessage';
 import MessageDataContent from '../../MessageDataContent';
 import SuggestedRepliesContainer from '../../SuggestedRepliesContainer';
@@ -94,6 +95,8 @@ export const ChatMessageList = () => {
                     }}
                   />
                 )}
+
+                {<BotReplySourcesPanel message={message} />}
               </div>
             </div>
           );


### PR DESCRIPTION
## Changes
- 

ticket: [AC-4318]

## Description

[UI displaying relevant sources for the answer](https://sendbird.atlassian.net/wiki/spaces/AC/pages/2601877524/v2+Widget+Client+Improvements)

[Sendbird AI ChatBot (3).webm](https://github.com/user-attachments/assets/acafd3fc-c0dd-4c24-ad76-44e1354e1b1b)

## Additional Notes
- Messages with below data in `extended_message_payload`, renders the button below the message component.
```
{
  bot_reply_sources: [
    {
      title: 'Sendbird docs',
      url: 'https://sendbird.com/docs',
    },
    {
      title: 'About cat',
      url: 'https://www.britannica.com/animal/cat',
    },
    {
      title: 'QWER',
      url: 'https://namu.wiki/w/QWER',
    },
  ],
}
```

## Checklist
Before requesting a code review, please check the following:
- [ ] **[Required]** CI has passed all checks.
- [ ] **[Required]** A self-review has been conducted to ensure there are no minor mistakes.
- [ ] **[Required]** Unnecessary comments/debugging code have been removed.
- [ ] **[Required]** All requirements specified in the ticket have been accurately implemented.
- [ ] Ensure the ticket has been updated with the sprint, status, and story points.


[AC-4318]: https://sendbird.atlassian.net/browse/AC-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ